### PR TITLE
fix #51 and #52.

### DIFF
--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -86,12 +86,22 @@ function upgradeDependencies(currentDependencies, latestVersions) {
 
             // Unconstrain the dependency, to allow upgrades of the form: '>1.2.x' -> '>2.0.x'
             var unconstrainedCurrentVersion = currentVersion.substr(getVersionConstraints(currentVersion).length, currentVersion.length);
-            var isLatest = semver.satisfies(latestVersion, unconstrainedCurrentVersion)
-            var isNewer = !semver.lte(latestVersion, unconstrainedCurrentVersion);
+            //console.log("upgradeDependencies: ", dependency, ", current: ", currentVersion, ", latest: ", latestVersion, ", unconstrained: ", unconstrainedCurrentVersion);
 
-            if (!isLatest && isNewer) {
-                var upgradedDependencyString = upgradeDependencyDeclaration(currentVersion, latestVersion);
-                upgradedDependencies[dependency] = upgradedDependencyString;
+            // We were unable to determine the latest unconstrained version of a package, don't try to upgrade it
+            if (!unconstrainedCurrentVersion)
+                continue;
+
+            try {
+                var isLatest = semver.satisfies(latestVersion, unconstrainedCurrentVersion);
+                var isNewer = !semver.lte(latestVersion, unconstrainedCurrentVersion);
+
+                if (!isLatest && isNewer) {
+                    var upgradedDependencyString = upgradeDependencyDeclaration(currentVersion, latestVersion);
+                    upgradedDependencies[dependency] = upgradedDependencyString;
+                }
+            } catch (ex) {
+                console.log("ignoring package '" + dependency + "' due to invalid version. ", ex);
             }
         }
     }


### PR DESCRIPTION
Now npm-check-updates properly skips the `#master` branch/git repository entries in the `package.json` and it skips any entries in `package.json` which are non-standard (i.e. contain no version at all or list an invalid version such as `0.1`)