### PR TITLE
Require get-stdin-promise only if needed

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -11,7 +11,6 @@ var closestPackage = require('closest-package');
 var _ = require('lodash');
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs'));
-var stdin = require('get-stdin-promise');
 var vm = require('./versionmanager');
 
 //
@@ -172,7 +171,7 @@ function programRunLocal() {
     var json;
 
     if(!process.stdin.isTTY) {
-        pkgData = stdin;
+        pkgData = require('get-stdin-promise');
         pkgFile = null; // this signals analyzeProjectDependencies to search for installed dependencies and to not print the upgrade message
     }
     else {


### PR DESCRIPTION
If the get-stdin-promise has been 'required' but not used,
it can prevent nodejs process from being terminated.