### PR TITLE
Changed behavior according to #94

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ results
 npm-debug.log
 
 node_modules
+
+.idea

--- a/bin/npm-check-updates
+++ b/bin/npm-check-updates
@@ -9,7 +9,6 @@ program
     .usage('[options] [filter]')
     .option('-d, --dev', 'check only devDependencies')
     .option('-e, --error-level <n>', 'set the error-level. 1: exits with error code 0 if no errors occur. 2: exits with error code 0 if no packages need updating (useful for continuous integration). Default is 1.', cint.partialAt(parseInt, 1, 10), 1)
-    .option('-f, --force', 'force upgrade even when the latest version satisfies the declared semver dependency')
     .option('-g, --global', 'check global packages instead of in the current project')
     // program.json is set to true in programInit if any options that begin with 'json' are true
     .option('-j, --jsonAll', 'output new package.json instead of human-readable message')
@@ -19,6 +18,7 @@ program
     .option('-s, --silent', "don't output anything")
     .option('-t, --greatest', "find the highest versions available instead of the latest stable versions")
     .option('-u, --upgrade', 'upgrade package.json dependencies to match latest versions (maintaining existing policy)')
+    .option('-a, --upgradeAll', 'upgrade package.json dependencies even when the latest version satisfies the declared semver dependency')
 
 program.parse(process.argv);
 

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -35,7 +35,7 @@ function upgradePackageDefinitions(currentDependencies) {
     var dependencyList = Object.keys(currentDependencies);
     return vm.getLatestVersions(dependencyList, {
         versionTarget: options.greatest ? 'greatest' : 'latest',
-        registry: options.registry ? options.registry : null,
+        registry: options.registry ? options.registry : null
     }).then(function (latestVersions) {
         var upgradedDependencies = vm.upgradeDependencies(currentDependencies, latestVersions);
         return [upgradedDependencies, latestVersions];
@@ -72,7 +72,7 @@ function analyzeProjectDependencies(pkgData, pkgFile) {
     .spread(function (current, installed, upgraded, latest) {
 
         if(options.json) {
-            var newPkgData = vm.updatePackageData(pkgData, current, upgraded);
+            var newPkgData = vm.updatePackageData(pkgData, current, upgraded, latest, options);
             print(options.jsonAll ? JSON.parse(newPkgData) :
                 options.jsonDeps ? _.pick(JSON.parse(newPkgData), 'dependencies', 'devDependencies') :
                 upgraded
@@ -83,13 +83,14 @@ function analyzeProjectDependencies(pkgData, pkgFile) {
 
             if(pkgFile && !_.isEmpty(upgraded)) {
                 if (options.upgrade) {
-                    var newPkgData = vm.updatePackageData(pkgData, current, upgraded);
+                    var newPkgData = vm.updatePackageData(pkgData, current, upgraded, latest, options);
                     writePackageFile(pkgFile, newPkgData)
                         .then(function () {
                             print('\n' + pkgFile + " upgraded");
                         });
                 } else {
                     print("Run with '-u' to upgrade your package.json");
+                    print("Run with '-ua' to upgrade even those that satisfy the declared version range");
                 }
                 if(options.errorLevel >= 2) {
                     throw new Error('Dependencies not up-to-date');
@@ -145,6 +146,9 @@ function programInit() {
     if(execName === 'npm-check-updates') {
         print('You can now use "ncu" for less typing!');
     }
+
+    // 'upgradeAll' is a type of an upgrade so if it's set, we set 'upgrade' as well
+    options.upgrade = options.upgrade || options.upgradeAll;
 
     if (options.global && options.upgrade) {
         print("npm-check-updates cannot update global packages.");

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -7,6 +7,7 @@ var options = {};
 var async = require('async');
 var cint = require('cint');
 var path = require('path');
+var util = require('util');
 var closestPackage = require('closest-package');
 var _ = require('lodash');
 var Promise = require('bluebird');
@@ -36,7 +37,7 @@ function upgradePackageDefinitions(currentDependencies) {
         versionTarget: options.greatest ? 'greatest' : 'latest',
         registry: options.registry ? options.registry : null,
     }).then(function (latestVersions) {
-        var upgradedDependencies = vm.upgradeDependencies(currentDependencies, latestVersions, { force: options.force });
+        var upgradedDependencies = vm.upgradeDependencies(currentDependencies, latestVersions);
         return [upgradedDependencies, latestVersions];
     });
 }
@@ -123,8 +124,10 @@ function printLocalUpgrades(current, upgraded, installed, latest) {
         for (var dep in upgraded) {
             var installedMessage = installed ? "Installed: " + (installed[dep] ? installed[dep] : "none") + ", " : '';
             var latestOrGreatestMessage = superlative + ": " + latest[dep];
-            var message = '"' + dep + '" can be updated from ' +
-                current[dep] + ' to ' + upgraded[dep] + " (" + installedMessage + latestOrGreatestMessage + ")";
+            var satisfiedOrUpdateMessage = vm.isSatisfied(latest[dep], current[dep])
+                ? 'satisfies current dependency'
+                : 'can be updated from ' + current[dep] + ' to ' + upgraded[dep];
+            var message = util.format('"%s" %s (%s%s)', dep, satisfiedOrUpdateMessage, installedMessage, latestOrGreatestMessage);
             print(message);
         }
     }

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -122,7 +122,6 @@ function upgradeDependencyDeclaration(declaration, latestVersion, options) {
  */
 function upgradeDependencies(currentDependencies, latestVersions) {
 
-    console.log(currentDependencies, latestVersions);
     // get the preferred wildcard and bind it to upgradeDependencyDeclaration
     var wildcard = getPreferredWildcard(currentDependencies);
     var upgradeDep = _.partialRight(upgradeDependencyDeclaration, {
@@ -215,15 +214,22 @@ function packageNameFilter(filter) {
 /**
  * Upgrade the dependency declarations in the package data
  * @param pkgData The package.json data, as utf8 text
- * @param oldDependencies Object of old dependencies {package: version}
- * @param newDependencies Object of old dependencies {package: version}
+ * @param oldDependencies Object of old dependencies {package: range}
+ * @param newDependencies Object of new dependencies {package: range}
+ * @param newVersions Object of new versions {package: version}
  * @returns {string} The updated package data, as utf8 text
  */
-function updatePackageData(pkgData, oldDependencies, newDependencies) {
+function updatePackageData(pkgData, oldDependencies, newDependencies, newVersions, options) {
+
+    options = options || {};
+    var upgradeAll = options.upgradeAll;
+
     for (var dependency in newDependencies) {
-        var expression = '"' + dependency + '"\\s*:\\s*"' + escapeRegexp(oldDependencies[dependency] + '"');
-        var regExp = new RegExp(expression, "g");
-        pkgData = pkgData.replace(regExp, '"' + dependency + '": ' + '"' + newDependencies[dependency] + '"');
+        if (upgradeAll || !isSatisfied(newVersions[dependency], oldDependencies[dependency])) {
+            var expression = '"' + dependency + '"\\s*:\\s*"' + escapeRegexp(oldDependencies[dependency] + '"');
+            var regExp = new RegExp(expression, "g");
+            pkgData = pkgData.replace(regExp, '"' + dependency + '": ' + '"' + newDependencies[dependency] + '"');
+        }
     }
 
     return pkgData;

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -120,17 +120,13 @@ function upgradeDependencyDeclaration(declaration, latestVersion, options) {
  * @param latestVersions latest available versions collection object
  * @returns {{}} upgraded dependency collection object
  */
-function upgradeDependencies(currentDependencies, latestVersions, options) {
+function upgradeDependencies(currentDependencies, latestVersions) {
 
-    options = options || {};
-
+    console.log(currentDependencies, latestVersions);
     // get the preferred wildcard and bind it to upgradeDependencyDeclaration
     var wildcard = getPreferredWildcard(currentDependencies);
     var upgradeDep = _.partialRight(upgradeDependencyDeclaration, {
         wildcard: wildcard
-    });
-    var isForcedUpgradeable = _.partialRight(isUpgradeable, {
-        force: options.force
     });
 
     return _(currentDependencies)
@@ -145,33 +141,32 @@ function upgradeDependencies(currentDependencies, latestVersions, options) {
         })
         // pick the packages that are upgradeable
         // we can use spread because isUpgradeable and upgradeDependencyDeclaration both take current and latest as arguments
-        .pick(_.spread(isForcedUpgradeable))
+        .pick(_.spread(isUpgradeable))
         .mapValues(_.spread(upgradeDep))
         .value();
 }
 
 // Determines if the given version (range) should be upgraded to the latest (i.e. it is valid, it does not currently satisfy the latest, and it is not beyond the latest)
-function isUpgradeable(current, latest, options) {
-
-    options = options || {};
+function isUpgradeable(current, latest) {
 
     // do not upgrade non-npm version declarations (such as git tags)
     if(!semver.validRange(current)) {
         return false;
     }
 
-    // if the force flag is set, remove the constraint (e.g. ^1.0.1 -> 1.0.1) to allow upgrades that satisfy the range, but are out of date
-    var version = options.force ?
-        versionUtil.stringify(semverutils.parseRange(current)[0]) :
-        current;
+    // remove the constraint (e.g. ^1.0.1 -> 1.0.1) to allow upgrades that satisfy the range, but are out of date
+    var version = versionUtil.stringify(semverutils.parseRange(current)[0]);
 
     // make sure it is a valid range
     // not upgradeable if the latest version satisfies the current range
     // not upgradeable if the specified version is newer than the latest (indicating a prerelease version)
     return !!semver.validRange(version)
-        && !semver.satisfies(latest, version)
+        && !isSatisfied(latest, version)
         && !semver.ltr(latest, version);
 }
+
+// Return true if the version satisfies the range
+var isSatisfied = semver.satisfies;
 
 // Convenience function to match a "wild" version digit
 function isWildDigit(d) {
@@ -429,4 +424,5 @@ exports.getLatestPackageVersion = getLatestPackageVersion;
 exports.getGreatestPackageVersion = getGreatestPackageVersion;
 exports.getLatestVersions = getLatestVersions;
 exports.isUpgradeable = isUpgradeable;
+exports.isSatisfied = isSatisfied;
 exports.getPreferredWildcard = getPreferredWildcard;

--- a/test/test-versionmanager.js
+++ b/test/test-versionmanager.js
@@ -107,7 +107,11 @@ describe('versionmanager', function () {
                 "bluebird": "^2.9",
                 "mocha": "^2"
             };
-            JSON.parse(vm.updatePackageData(pkgData, oldDependencies, newDependencies))
+            var newVersions = {
+                "bluebird": "2.9.0",
+                "mocha": "2.2.5"
+            };
+            JSON.parse(vm.updatePackageData(pkgData, oldDependencies, newDependencies, newVersions))
             .should.eql({
               "name": "npm-check-updates",
               "dependencies": {
@@ -203,12 +207,8 @@ describe('versionmanager', function () {
             vm.upgradeDependencies({ mongodb: '0.5' }, { mongodb: '1.4.30' }).should.eql({ mongodb: '1.4' });
         });
 
-        it('should not upgrade latest versions that already satisfy the specified version', function() {
-            vm.upgradeDependencies({ mongodb: '^1.0.0' }, { mongodb: '1.4.30' }).should.eql({});
-        });
-
-        it('should upgrade latest versions that already satisfy the specified version if force option is specified', function() {
-            vm.upgradeDependencies({ mongodb: '^1.0.0' }, { mongodb: '1.4.30' }, { force: true }).should.eql({
+        it('should upgrade latest versions that already satisfy the specified version', function() {
+            vm.upgradeDependencies({ mongodb: '^1.0.0' }, { mongodb: '1.4.30' }).should.eql({
                 mongodb: '^1.4.30'
             });
         });
@@ -253,6 +253,9 @@ describe('versionmanager', function () {
     });
 
     describe('getLatestVersions', function () {
+        // We increase the timeout to allow for more time to retrieve the version information
+        this.timeout(30000);
+
         it('valid single package', function () {
             var latestVersions = vm.getLatestVersions(["async"]);
             return latestVersions.should.eventually.have.property('async');
@@ -304,7 +307,7 @@ describe('versionmanager', function () {
         it("should handle comparison constraints", function() {
             vm.isUpgradeable(">1.0", "0.5.1").should.equal(false);
             vm.isUpgradeable("<3.0 >0.1", "0.5.1").should.equal(false);
-            vm.isUpgradeable(">0.1.x", "0.5.1").should.equal(false);
+            vm.isUpgradeable(">0.1.x", "0.5.1").should.equal(true);
         });
 
     });

--- a/test/test-versionmanager.js
+++ b/test/test-versionmanager.js
@@ -1,13 +1,12 @@
 var vm = require("../lib/versionmanager");
 var chai = require("chai");
-var should = chai.should();
 var chaiAsPromised = require("chai-as-promised");
 
 chai.use(chaiAsPromised);
 
 describe('versionmanager', function () {
 
-    before(function() {
+    before(function () {
         return vm.initialize(false).should.be.resolved;
     });
 
@@ -37,12 +36,12 @@ describe('versionmanager', function () {
 
         it('should convert < to ^', function () {
             vm.upgradeDependencyDeclaration("<1.0", "1.1.0").should.equal("^1.1");
-        })
+        });
 
         it('should preserve > and >=', function () {
             vm.upgradeDependencyDeclaration(">1.0", "2.0.0").should.equal(">2.0");
             vm.upgradeDependencyDeclaration(">=1.0", "2.0.0").should.equal(">=2.0");
-        })
+        });
 
         it('should preserve ^ and ~', function () {
             vm.upgradeDependencyDeclaration("^1.2.3", "1.2.4").should.equal("^1.2.4");
@@ -88,7 +87,7 @@ describe('versionmanager', function () {
         });
     });
 
-    describe('updatePackageData', function() {
+    describe('updatePackageData', function () {
         var pkgData = JSON.stringify({
             "name": "npm-check-updates",
             "dependencies": {
@@ -115,22 +114,22 @@ describe('versionmanager', function () {
             "mocha": "2.2.5"
         };
 
-        it('should upgrade the dependencies in the given package data (except for satisfied)', function() {
+        it('should upgrade the dependencies in the given package data (except for satisfied)', function () {
             JSON.parse(vm.updatePackageData(pkgData, oldDependencies, newDependencies, newVersions))
-            .should.eql({
-              "name": "npm-check-updates",
-              "dependencies": {
-                "bluebird": "^2.9",
-                "bindings": "^1.1.0"
-              },
-              "devDependencies": {
-                "mocha": "^2"
-              }
-            })
+                .should.eql({
+                    "name": "npm-check-updates",
+                    "dependencies": {
+                        "bluebird": "^2.9",
+                        "bindings": "^1.1.0"
+                    },
+                    "devDependencies": {
+                        "mocha": "^2"
+                    }
+                })
         });
 
-        it('should upgrade the dependencies in the given package data (including satisfied)', function() {
-            JSON.parse(vm.updatePackageData(pkgData, oldDependencies, newDependencies, newVersions, { upgradeAll: true }))
+        it('should upgrade the dependencies in the given package data (including satisfied)', function () {
+            JSON.parse(vm.updatePackageData(pkgData, oldDependencies, newDependencies, newVersions, {upgradeAll: true}))
                 .should.eql({
                     "name": "npm-check-updates",
                     "dependencies": {
@@ -144,10 +143,10 @@ describe('versionmanager', function () {
         });
     });
 
-    describe('getCurrentDependencies', function() {
+    describe('getCurrentDependencies', function () {
 
         var deps;
-        beforeEach(function() {
+        beforeEach(function () {
             deps = {
                 dependencies: {
                     mocha: '1.2'
@@ -156,64 +155,64 @@ describe('versionmanager', function () {
                     lodash: '^3.9.3'
                 }
             };
-        })
+        });
 
-        it('should return an empty object for an empty package.json and handle default options', function() {
+        it('should return an empty object for an empty package.json and handle default options', function () {
             vm.getCurrentDependencies().should.eql({});
             vm.getCurrentDependencies({}).should.eql({});
             vm.getCurrentDependencies({}, {}).should.eql({});
         });
 
-        it('should get dependencies and devDependencies by default', function() {
+        it('should get dependencies and devDependencies by default', function () {
             vm.getCurrentDependencies(deps).should.eql({
                 mocha: '1.2',
                 lodash: '^3.9.3'
             });
         });
 
-        it('should only get dependencies when the prod option is true', function() {
-            vm.getCurrentDependencies(deps, { prod: true }).should.eql({
+        it('should only get dependencies when the prod option is true', function () {
+            vm.getCurrentDependencies(deps, {prod: true}).should.eql({
                 mocha: '1.2'
             });
         });
 
-        it('should only get devDependencies when the dev option is true', function() {
-            vm.getCurrentDependencies(deps, { dev: true }).should.eql({
+        it('should only get devDependencies when the dev option is true', function () {
+            vm.getCurrentDependencies(deps, {dev: true}).should.eql({
                 lodash: '^3.9.3'
             });
         });
 
-        it('should filter dependencies by package name', function() {
-            vm.getCurrentDependencies(deps, { filter: 'mocha' }).should.eql({
+        it('should filter dependencies by package name', function () {
+            vm.getCurrentDependencies(deps, {filter: 'mocha'}).should.eql({
                 mocha: '1.2'
             });
         });
 
-        it('should not filter out dependencies with a partial package name', function() {
-            vm.getCurrentDependencies(deps, { filter: 'o' }).should.eql({});
+        it('should not filter out dependencies with a partial package name', function () {
+            vm.getCurrentDependencies(deps, {filter: 'o'}).should.eql({});
         });
 
-        it('should filter dependencies by multiple packages', function() {
-            vm.getCurrentDependencies(deps, { filter: 'mocha lodash' }).should.eql({
+        it('should filter dependencies by multiple packages', function () {
+            vm.getCurrentDependencies(deps, {filter: 'mocha lodash'}).should.eql({
                 mocha: '1.2',
                 lodash: '^3.9.3'
             });
-            vm.getCurrentDependencies(deps, { filter: 'mocha,lodash' }).should.eql({
+            vm.getCurrentDependencies(deps, {filter: 'mocha,lodash'}).should.eql({
                 mocha: '1.2',
                 lodash: '^3.9.3'
             });
-            vm.getCurrentDependencies(deps, { filter: ['mocha', 'lodash'] }).should.eql({
+            vm.getCurrentDependencies(deps, {filter: ['mocha', 'lodash']}).should.eql({
                 mocha: '1.2',
                 lodash: '^3.9.3'
             });
         });
 
-        it('should filter dependencies by regex', function() {
-            vm.getCurrentDependencies(deps, { filter: /o/ }).should.eql({
+        it('should filter dependencies by regex', function () {
+            vm.getCurrentDependencies(deps, {filter: /o/}).should.eql({
                 mocha: '1.2',
                 lodash: '^3.9.3'
             });
-            vm.getCurrentDependencies(deps, { filter: '/o/' }).should.eql({
+            vm.getCurrentDependencies(deps, {filter: '/o/'}).should.eql({
                 mocha: '1.2',
                 lodash: '^3.9.3'
             });
@@ -221,33 +220,33 @@ describe('versionmanager', function () {
 
     });
 
-    describe('upgradeDependencies', function() {
+    describe('upgradeDependencies', function () {
 
-        it('should upgrade simple versions', function() {
-            vm.upgradeDependencies({ mongodb: '0.5' }, { mongodb: '1.4.30' }).should.eql({ mongodb: '1.4' });
+        it('should upgrade simple versions', function () {
+            vm.upgradeDependencies({mongodb: '0.5'}, {mongodb: '1.4.30'}).should.eql({mongodb: '1.4'});
         });
 
-        it('should upgrade latest versions that already satisfy the specified version', function() {
-            vm.upgradeDependencies({ mongodb: '^1.0.0' }, { mongodb: '1.4.30' }).should.eql({
+        it('should upgrade latest versions that already satisfy the specified version', function () {
+            vm.upgradeDependencies({mongodb: '^1.0.0'}, {mongodb: '1.4.30'}).should.eql({
                 mongodb: '^1.4.30'
             });
         });
 
-        it('should not downgrade', function() {
-            vm.upgradeDependencies({ mongodb: '^2.0.7' }, { mongodb: '1.4.30' }).should.eql({});
+        it('should not downgrade', function () {
+            vm.upgradeDependencies({mongodb: '^2.0.7'}, {mongodb: '1.4.30'}).should.eql({});
         });
 
-        it('should use the preferred wildcard when converting <, closed, or mixed ranges', function() {
-            vm.upgradeDependencies({ a: '1.*', mongodb: '<1.0' }, { mongodb: '3.0.0' }).should.eql({ mongodb: '3.*' });
-            vm.upgradeDependencies({ a: '1.x', mongodb: '<1.0' }, { mongodb: '3.0.0' }).should.eql({ mongodb: '3.x' });
-            vm.upgradeDependencies({ a: '~1', mongodb: '<1.0' }, { mongodb: '3.0.0' }).should.eql({ mongodb: '~3.0' });
-            vm.upgradeDependencies({ a: '^1', mongodb: '<1.0' }, { mongodb: '3.0.0' }).should.eql({ mongodb: '^3.0' });
+        it('should use the preferred wildcard when converting <, closed, or mixed ranges', function () {
+            vm.upgradeDependencies({a: '1.*', mongodb: '<1.0'}, {mongodb: '3.0.0'}).should.eql({mongodb: '3.*'});
+            vm.upgradeDependencies({a: '1.x', mongodb: '<1.0'}, {mongodb: '3.0.0'}).should.eql({mongodb: '3.x'});
+            vm.upgradeDependencies({a: '~1', mongodb: '<1.0'}, {mongodb: '3.0.0'}).should.eql({mongodb: '~3.0'});
+            vm.upgradeDependencies({a: '^1', mongodb: '<1.0'}, {mongodb: '3.0.0'}).should.eql({mongodb: '^3.0'});
 
-            vm.upgradeDependencies({ a: '1.*', mongodb: '1.0 < 2.0' }, { mongodb: '3.0.0' }).should.eql({ mongodb: '3.*' });
-            vm.upgradeDependencies({ mongodb: '1.0 < 2.*' }, { mongodb: '3.0.0' }).should.eql({ mongodb: '3.*' });
+            vm.upgradeDependencies({a: '1.*', mongodb: '1.0 < 2.0'}, {mongodb: '3.0.0'}).should.eql({mongodb: '3.*'});
+            vm.upgradeDependencies({mongodb: '1.0 < 2.*'}, {mongodb: '3.0.0'}).should.eql({mongodb: '3.*'});
         });
-        it('should convert closed ranges to caret (^) when preferred wildcard is unknown', function() {
-            vm.upgradeDependencies({ mongodb: '1.0 < 2.0' }, { mongodb: '3.0.0' }).should.eql({ mongodb: '^3.0' });
+        it('should convert closed ranges to caret (^) when preferred wildcard is unknown', function () {
+            vm.upgradeDependencies({mongodb: '1.0 < 2.0'}, {mongodb: '3.0.0'}).should.eql({mongodb: '^3.0'});
         });
     });
 
@@ -282,8 +281,8 @@ describe('versionmanager', function () {
         });
 
         it('valid packages', function () {
-            var latestVersions = vm.getLatestVersions(["async", "npm"])
-            latestVersions.should.eventually.have.property('async')
+            var latestVersions = vm.getLatestVersions(["async", "npm"]);
+            latestVersions.should.eventually.have.property('async');
             latestVersions.should.eventually.have.property('npm');
             return latestVersions;
         });
@@ -294,37 +293,37 @@ describe('versionmanager', function () {
         });
 
         it('set the versionTarget explicitly to latest', function () {
-            return vm.getLatestVersions(["async"], { versionTarget: 'latest' })
+            return vm.getLatestVersions(["async"], {versionTarget: 'latest'})
                 .should.eventually.have.property('async');
         });
 
         it('set the versionTarget to greatest', function () {
-            return vm.getLatestVersions(["async"], { versionTarget: 'greatest' })
+            return vm.getLatestVersions(["async"], {versionTarget: 'greatest'})
                 .should.eventually.have.property('async');
         });
 
         it('should return an error for an unsupported versionTarget', function () {
-            var a = vm.getLatestVersions(["async"], { versionTarget: 'foo' })
+            var a = vm.getLatestVersions(["async"], {versionTarget: 'foo'});
             return a.should.be.rejected;
         });
 
     });
 
-    describe("isUpgradeable", function() {
+    describe("isUpgradeable", function () {
 
-        it("should upgrade versions that do not satisfy latest versions", function() {
+        it("should upgrade versions that do not satisfy latest versions", function () {
             vm.isUpgradeable("0.1.x", "0.5.1").should.equal(true);
         });
 
-        it("should not upgrade invalid versions", function() {
+        it("should not upgrade invalid versions", function () {
             vm.isUpgradeable("https://github.com/strongloop/express", "4.11.2").should.equal(false);
         });
 
-        it("should not upgrade versions beyond the latest", function() {
+        it("should not upgrade versions beyond the latest", function () {
             vm.isUpgradeable("5.0.0", "4.11.2").should.equal(false);
         });
 
-        it("should handle comparison constraints", function() {
+        it("should handle comparison constraints", function () {
             vm.isUpgradeable(">1.0", "0.5.1").should.equal(false);
             vm.isUpgradeable("<3.0 >0.1", "0.5.1").should.equal(false);
             vm.isUpgradeable(">0.1.x", "0.5.1").should.equal(true);
@@ -332,53 +331,53 @@ describe('versionmanager', function () {
 
     });
 
-    describe('getPreferredWildcard', function() {
+    describe('getPreferredWildcard', function () {
 
-        it('should identify ^ when it is preferred', function() {
+        it('should identify ^ when it is preferred', function () {
             var deps = {
                 async: '^0.9.0',
                 bluebird: '^2.9.27',
                 cint: '^8.2.1',
                 commander: '~2.8.1',
-                lodash: '^3.2.0',
+                lodash: '^3.2.0'
             };
             vm.getPreferredWildcard(deps).should.equal('^');
         });
 
-        it('should identify ~ when it is preferred', function() {
+        it('should identify ~ when it is preferred', function () {
             var deps = {
                 async: '~0.9.0',
                 bluebird: '~2.9.27',
                 cint: '^8.2.1',
                 commander: '~2.8.1',
-                lodash: '^3.2.0',
+                lodash: '^3.2.0'
             };
             vm.getPreferredWildcard(deps).should.equal('~');
         });
 
-        it('should identify .x when it is preferred', function() {
+        it('should identify .x when it is preferred', function () {
             var deps = {
                 async: '0.9.x',
                 bluebird: '2.9.x',
                 cint: '^8.2.1',
                 commander: '~2.8.1',
-                lodash: '3.x',
+                lodash: '3.x'
             };
             vm.getPreferredWildcard(deps).should.equal('.x');
         });
 
-        it('should identify .* when it is preferred', function() {
+        it('should identify .* when it is preferred', function () {
             var deps = {
                 async: '0.9.*',
                 bluebird: '2.9.*',
                 cint: '^8.2.1',
                 commander: '~2.8.1',
-                lodash: '3.*',
+                lodash: '3.*'
             };
             vm.getPreferredWildcard(deps).should.equal('.*');
         });
 
-        it('should use the first wildcard if there is a tie', function() {
+        it('should use the first wildcard if there is a tie', function () {
             var deps = {
                 async: '0.9.x',
                 commander: '2.8.*'
@@ -386,11 +385,11 @@ describe('versionmanager', function () {
             vm.getPreferredWildcard(deps).should.equal('.x');
         });
 
-        it('should default to caret (^) when cannot be determined from other dependencies', function() {
+        it('should default to caret (^) when cannot be determined from other dependencies', function () {
             var deps = {
                 async: '0.9.0',
                 commander: '2.8.1',
-                lodash: '3.2.0',
+                lodash: '3.2.0'
             };
             vm.getPreferredWildcard(deps).should.equal('^');
         });

--- a/test/test-versionmanager.js
+++ b/test/test-versionmanager.js
@@ -89,38 +89,58 @@ describe('versionmanager', function () {
     });
 
     describe('updatePackageData', function() {
-        it('should upgrade the dependencies in the given package data', function() {
-            var pkgData = JSON.stringify({
-              "name": "npm-check-updates",
-              "dependencies": {
-                "bluebird": "<2.0"
-              },
-              "devDependencies": {
-                "mocha": "^1"
-              }
-            });
-            var oldDependencies = {
+        var pkgData = JSON.stringify({
+            "name": "npm-check-updates",
+            "dependencies": {
                 "bluebird": "<2.0",
+                "bindings": "^1.1.0"
+            },
+            "devDependencies": {
                 "mocha": "^1"
-            };
-            var newDependencies = {
-                "bluebird": "^2.9",
-                "mocha": "^2"
-            };
-            var newVersions = {
-                "bluebird": "2.9.0",
-                "mocha": "2.2.5"
-            };
+            }
+        });
+        var oldDependencies = {
+            "bluebird": "<2.0",
+            "bindings": "^1.1.0",
+            "mocha": "^1"
+        };
+        var newDependencies = {
+            "bluebird": "^2.9",
+            "bindings": "^1.2.1",
+            "mocha": "^2"
+        };
+        var newVersions = {
+            "bluebird": "2.9.0",
+            "bindings": "1.2.1",
+            "mocha": "2.2.5"
+        };
+
+        it('should upgrade the dependencies in the given package data (except for satisfied)', function() {
             JSON.parse(vm.updatePackageData(pkgData, oldDependencies, newDependencies, newVersions))
             .should.eql({
               "name": "npm-check-updates",
               "dependencies": {
-                "bluebird": "^2.9"
+                "bluebird": "^2.9",
+                "bindings": "^1.1.0"
               },
               "devDependencies": {
                 "mocha": "^2"
               }
             })
+        });
+
+        it('should upgrade the dependencies in the given package data (including satisfied)', function() {
+            JSON.parse(vm.updatePackageData(pkgData, oldDependencies, newDependencies, newVersions, { upgradeAll: true }))
+                .should.eql({
+                    "name": "npm-check-updates",
+                    "dependencies": {
+                        "bluebird": "^2.9",
+                        "bindings": "^1.2.1"
+                    },
+                    "devDependencies": {
+                        "mocha": "^2"
+                    }
+                })
         });
     });
 


### PR DESCRIPTION
Resolves #94.

Change-log:
- Default behavior without -u to shows all upgrades (e.g. for satisfied versions we show `"<package>" satisfies current dependency (Installed: <old>, Latest: <new>)`)
- Default behavior with -u only upgrades those that are not satisfied (like the current behavior of v2 alpha)
- Using -ua (-a) / --upgradeAll flags to upgrade even satisfied versions (like the behavior of v1)
- The note at the end of the version upgrades was changed to:
```
Run with '-u' to upgrade your package.json
Run with '-ua' to upgrade even those that satisfy the declared version range
```