### PR TITLE
Fix old alias handling

### DIFF
--- a/bin/old-alias
+++ b/bin/old-alias
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-process.env.ncu_old_alias = 'true';
+console.log('You can now use "ncu" for less typing!');
 
 require('./npm-check-updates');

--- a/bin/old-alias
+++ b/bin/old-alias
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+process.env.ncu_old_alias = 'true';
+
+require('./npm-check-updates');

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -142,8 +142,7 @@ function printLocalUpgrades(current, upgraded, installed, latest) {
 
 function programInit() {
 
-    var execName = path.basename(process.argv[1]);
-    if(execName === 'npm-check-updates') {
+    if (process.env.ncu_old_alias) {
         print('You can now use "ncu" for less typing!');
     }
 

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -142,10 +142,6 @@ function printLocalUpgrades(current, upgraded, installed, latest) {
 
 function programInit() {
 
-    if (process.env.ncu_old_alias) {
-        print('You can now use "ncu" for less typing!');
-    }
-
     // 'upgradeAll' is a type of an upgrade so if it's set, we set 'upgrade' as well
     options.upgrade = options.upgrade || options.upgradeAll;
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "mocha -t 10000"
   },
   "bin": {
-    "npm-check-updates": "./bin/npm-check-updates",
+    "npm-check-updates": "./bin/old-alias",
     "ncu": "./bin/npm-check-updates"
   },
   "repository": {


### PR DESCRIPTION
This resolves #90

Instead of using argv to check if `npm-check-updates` was called or `ncu`, we load different files for each bin. When `npm-check-updates` is called, `/bin/old-alias` is loaded and prints:
"You can now use "ncu" for less typing!"
We then require the regular startup script and continue as usual.