### PR TITLE
Output the -u msg only if unsatisfied > 0

### DIFF
--- a/bin/npm-check-updates
+++ b/bin/npm-check-updates
@@ -18,7 +18,7 @@ program
     .option('-s, --silent', "don't output anything")
     .option('-t, --greatest', "find the highest versions available instead of the latest stable versions")
     .option('-u, --upgrade', 'upgrade package.json dependencies to match latest versions (maintaining existing policy)')
-    .option('-a, --upgradeAll', 'upgrade package.json dependencies even when the latest version satisfies the declared semver dependency')
+    .option('-a, --upgradeAll', 'upgrade package.json dependencies even when the latest version satisfies the declared semver dependency');
 
 program.parse(process.argv);
 

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -7,7 +7,6 @@ var options = {};
 var async          = require('async');
 var cint           = require('cint');
 var path           = require('path');
-var util           = require('util');
 var closestPackage = require('closest-package');
 var _              = require('lodash');
 var Promise        = require('bluebird');
@@ -27,8 +26,7 @@ function print(message) {
     }
 }
 
-function createDependencyTable(options) {
-    options = options || {};
+function createDependencyTable() {
     return new Table({
         colAligns: ['left', 'right', 'right', 'right'],
         chars: {
@@ -104,9 +102,10 @@ function analyzeProjectDependencies(pkgData, pkgFile) {
     .spread(function (current, installed, upgraded, latest) {
 
         var output;
+        var newPkgData;
 
         if(options.json) {
-            var newPkgData = vm.updatePackageData(pkgData, current, upgraded, latest, options);
+            newPkgData = vm.updatePackageData(pkgData, current, upgraded, latest, options);
             output = options.jsonAll ? JSON.parse(newPkgData) :
                 options.jsonDeps ? _.pick(JSON.parse(newPkgData), 'dependencies', 'devDependencies') :
                 upgraded;
@@ -119,19 +118,20 @@ function analyzeProjectDependencies(pkgData, pkgFile) {
                 installed: installed,
                 current: current,
                 upgraded: upgraded,
-                latest: latest
+                latest: latest,
+                pkgFile: pkgFile,
+                isUpgrade: options.upgrade
             });
 
             if(pkgFile && !_.isEmpty(upgraded)) {
                 if (options.upgrade) {
-                    var newPkgData = vm.updatePackageData(pkgData, current, upgraded, latest, options);
+                    newPkgData = vm.updatePackageData(pkgData, current, upgraded, latest, options);
                     writePackageFile(pkgFile, newPkgData)
                         .then(function () {
-                            print('\n' + pkgFile + ' upgraded. Update the dependencies by running ' + chalk.blue('npm update'));
+                            print('Upgraded ' + pkgFile + '\nUpdate the installed dependencies by running ' + chalk.blue('npm update') + '\n');
                         });
-                } else {
-                    print('Run with ' + chalk.blue('-u') + ' to upgrade your package.json\n');
                 }
+
                 if(options.errorLevel >= 2) {
                     throw new Error('Dependencies not up-to-date');
                 }
@@ -154,15 +154,17 @@ function toDependencyTable(args, options) {
         var to = versionUtil.colorizeDiff(args.to[dep] || '', args.from[dep]);
         return [dep, from, '→', to];
     });
-    rows.forEach(function (row) { table.push(row); })
+    rows.forEach(function (row) { table.push(row); });
     return table;
 }
 
 /**
- * @param current
- * @param upgraded
- * @param installed (optional)
- * @param latest (optional)
+ * @param args.current
+ * @param args.upgraded
+ * @param args.installed (optional)
+ * @param args.latest (optional)
+ * @param args.pkgFile (optional)
+ * @param args.isUpgrade (optional)
  */
 function printUpgrades(args) {
     print('');
@@ -180,7 +182,7 @@ function printUpgrades(args) {
         var deps = Object.keys(args.upgraded);
         var satisfied = cint.toObject(deps, function (dep) {
           return cint.keyValue(dep, vm.isSatisfied(args.latest[dep], args.current[dep]));
-        })
+        });
         var isSatisfied = _.propertyOf(satisfied);
         var unsatisfiedUpgraded = cint.filterObject(args.upgraded, cint.not(isSatisfied));
         var numUnsatisfied = Object.keys(unsatisfiedUpgraded).length;
@@ -212,8 +214,11 @@ function printUpgrades(args) {
                 // adding some space between the unsatisfied to the satisfied
                 print('');
             }
-            print('The following ' + (count === 1 ? 'dependency is' : 'dependencies are') + ' satisfied by ' + (count === 1 ? 'its' : 'their') + ' declared version range, but the installed version' + (count === 1 ? ' is' : 's are') + ' behind. Update without modifying your package.json by running ' + chalk.blue('npm update') + '. Upgrade your package.json by running ' + chalk.blue('ncu -ua') + '\n')
+            print('The following ' + (count === 1 ? 'dependency is' : 'dependencies are') + ' satisfied by ' + (count === 1 ? 'its' : 'their') + ' declared version range, but the installed version' + (count === 1 ? ' is' : 's are') + ' behind. Update without modifying your package.json by running ' + chalk.blue('npm update') + '. Upgrade your package.json by running ' + chalk.blue('ncu -ua') + '\n');
             print(satisfiedTable.toString());
+        }
+        if (numUnsatisfied > 0 && args.pkgFile && !args.isUpgrade) {
+            print('\nRun with ' + chalk.blue('-u') + ' to upgrade your package.json');
         }
     }
     print('');


### PR DESCRIPTION
If you only have satisfied updates, we still show the "Run with -u to upgrade your package.json". I think we shouldn't show it, because it won't do anything in this specific case.