### PR TITLE
Provide helpful errors on JSON.parse exceptions

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -14,6 +14,7 @@ var chalk = require('chalk');
 var fs = Promise.promisifyAll(require('fs'));
 var vm = require('./versionmanager');
 var versionUtil = require('./version-util');
+var jph = require('json-parse-helpfulerror');
 
 //
 // Helper functions
@@ -101,9 +102,9 @@ function analyzeProjectDependencies(pkgData, pkgFile) {
     var pkg;
 
     try {
-        pkg = JSON.parse(pkgData);
-    } catch(e) {
-        programError(chalk.red('Invalid package.json' + (pkgFile ? ': ' + pkgFile : ' from stdin')));
+        pkg = jph.parse(pkgData);
+    } catch (e) {
+        programError(chalk.red('Invalid package.json' + (pkgFile ? ': ' + pkgFile : ' from stdin') + '. Error details:\n' + e.message));
     }
 
     var current = vm.getCurrentDependencies(pkg, {
@@ -130,9 +131,9 @@ function analyzeProjectDependencies(pkgData, pkgFile) {
         if (options.json) {
             newPkgData = vm.updatePackageData(pkgData, current, upgraded, latest, options);
             // don't need try-catch here because pkgData has already been parsed as valid JSON, and vm.updatePackageData simply does a find-and-replace on that
-            output = options.jsonAll ? JSON.parse(newPkgData) :
+            output = options.jsonAll ? jph.parse(newPkgData) :
                 options.jsonDeps ?
-                    _.pick(JSON.parse(newPkgData), 'dependencies', 'devDependencies', 'optionalDependencies') :
+                    _.pick(jph.parse(newPkgData), 'dependencies', 'devDependencies', 'optionalDependencies') :
                     upgraded;
 
             printJson(JSON.stringify(output));
@@ -293,7 +294,11 @@ function programRunLocal() {
         pkgData = require('get-stdin-promise');
     } else {
         // find the closest descendant package
-        pkgFile = closestPackage.sync(process.cwd());
+        try {
+            pkgFile = closestPackage.sync(process.cwd());
+        } catch (e) {
+            programError(chalk.red('Invalid package.json. Error details:\n' + e.message));
+        }
     }
 
     // if pkgFile was set, make sure it exists and read it into pkgData

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "commander": "^2.8.1",
     "fast-diff": "^1.0.1",
     "get-stdin-promise": "^0.1.1",
+    "json-parse-helpfulerror": "^1.0.3",
     "lodash": "^3.10.1",
     "npm": "^2.13.4",
     "semver": "^5.0.1",


### PR DESCRIPTION
This commit uses `json-parse-helpfulerror` module to parse JSONs instead of `JSON.parse`. The benefit of using it, is that when the parse fails and throws, it provides clues to why it failed (e.g. "Trailing comma at 15:3"). So it's easier to figure out, what's wrong and fix it. 
The performance should pretty much be the same, since it first tries to use `JSON.parse` and only if it throws, we analyzes the cause.

`closestPackage.sync` that we call when we try to find the closest package,json, can throw exceptions because it tries to parse the content of the file, so I wrapped it in a try catch to give a better error message. I also opened a PR [there](hughsk/closest-package#1), so they will also throw more helpful errors (e.g. the new errors will include the path to the package.json that caused the exception, so users will know what to fix).

This commit continues the work started in https://github.com/tjunnone/npm-check-updates/commit/a98bef5ecda0113aff6324ffc193412fff24c70d