### PR TITLE
Depend on semver-utils from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "npm": "^3.3.3",
     "require-dir": "^0.3.0",
     "semver": "^5.0.1",
-    "semver-utils": "metaraine/semver-utils.git#86ea225",
+    "semver-utils": "^1.1.1",
     "update-notifier": "^0.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Change dependency on semver-utils to use the NPM package, now that [this PR](https://github.com/coolaj86/semver-utils/pull/2) has been merged.