### PR TITLE
Fix "Promise handler was created but not returned from" warning

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -190,6 +190,7 @@ function analyzeProjectDependencies(pkgData, pkgFile) {
                 pkgFile: pkgFile,
                 isUpgrade: options.upgrade
             });
+            return null;
         }
     });
 }

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -295,8 +295,8 @@ function getLatestVersions(packageList, options) {
             break;
         default:
             var supportedVersionTargets = ['latest', 'greatest'];
-            return Promise.reject('Unsupported versionTarget: ' + options.versionTarget +
-                '. Supported version targets are: ' + supportedVersionTargets);
+            return Promise.reject(new Error('Unsupported versionTarget: ' + options.versionTarget +
+                '. Supported version targets are: ' + supportedVersionTargets));
     }
 
     // ignore 404 errors from getPackageVersion by having them return null instead of rejecting


### PR DESCRIPTION
When running ncu -a we get the following warning:
```
Warning: a promise was created in a handler but was not returned from it
    at printUpgrades (...\npm\node_modules\npm-check-updates\lib\npm-check-updates.js:289:13)
    at ...\npm\node_modules\npm-check-updates\lib\npm-check-updates.js:189:20
From previous event:
    at analyzeProjectDependencies (...\npm\node_modules\npm-check-updates\lib\npm-check-updates.js:165:6)
```

Another warning fix added for the following:
```
Warning: a promise was rejected with a non-error: [object String]
    at Object.getLatestVersions (...\npm\node_modules\npm-check-updates\lib\versionmanager.js:298:28)
```


These two small things have been bothering me for a while :smile: 


Node 5.4.0 on Windows 10