### PR TITLE
Fixes: ncu -g doesn't work on homebrew (#146)

### DIFF
--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -57,6 +57,12 @@ module.exports = {
         }))
         .then(function () {
             rawPromisify(npm.commands);
+
+            // FIX: for ncu -g doesn't work on homebrew or windows #146
+            // https://github.com/tjunnone/npm-check-updates/issues/146
+            if (args.global && npm.config.get('prefix').match('Cellar')) {
+                npm.config.set('prefix', '/usr/local');
+            }
             return initialized = true;
         });
     },


### PR DESCRIPTION
Automatically sets the correct node prefix path when node and npm are installed via homebrew, removes the need to prefix the command with `PREFIX=/usr/local`.