### PR TITLE
Specify `ncu` where instructions appear in output

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -286,7 +286,7 @@ function printUpgrades(args) {
         }, {
             greatest: options.greatest
         });
-        print((numUnsatisfied > 0 ? '\n' : '') + 'The following dependenc' + (numSatisfied === 1 ? 'y is' : 'ies are') + ' satisfied by ' + (numSatisfied === 1 ? 'its' : 'their') + ' declared version range, but the installed version' + (numSatisfied === 1 ? ' is' : 's are') + ' behind. You can install the latest version' + (numSatisfied === 1 ? '' : 's') + ' without modifying your package file by using ' + chalk.blue(options.packageManager + ' update') + '. If you want to update the dependenc' + (numSatisfied === 1 ? 'y' : 'ies') + ' in your package file anyway, use ' + chalk.blue('-a/--upgradeAll') + '.\n');
+        print((numUnsatisfied > 0 ? '\n' : '') + 'The following dependenc' + (numSatisfied === 1 ? 'y is' : 'ies are') + ' satisfied by ' + (numSatisfied === 1 ? 'its' : 'their') + ' declared version range, but the installed version' + (numSatisfied === 1 ? ' is' : 's are') + ' behind. You can install the latest version' + (numSatisfied === 1 ? '' : 's') + ' without modifying your package file by using ' + chalk.cyan('ncu ') + chalk.blue(options.packageManager + ' update') + '. If you want to update the dependenc' + (numSatisfied === 1 ? 'y' : 'ies') + ' in your package file anyway, use ' + chalk.cyan('ncu ') + chalk.blue('-a/--upgradeAll') + '.\n');
         print(satisfiedTable.toString());
     }
 
@@ -300,7 +300,7 @@ function printUpgrades(args) {
                     print('Upgraded ' + args.pkgFile + '\n');
                 });
         } else {
-            print('\nRun with ' + chalk.blue(numUnsatisfied > 0 ? '-u' : '-a') + ' to upgrade ' + getPackageFileName());
+            print('\nRun ' + chalk.cyan('ncu') + ' with ' + chalk.blue(numUnsatisfied > 0 ? '-u' : '-a') + ' to upgrade ' + getPackageFileName());
         }
         if (options.errorLevel >= 2) {
             programError('Dependencies not up-to-date');


### PR DESCRIPTION
I'd like to add `ncu` to a postinstall step of a work project. The current output ends in `Run with -u to upgrade package.json` which might lead developers (coworkers who may not be as familiar with npm) to try `npm install -u`; not the intended effect!

This PR clarifies that it is `ncu` that must be run, not `npm install`.