### PR TITLE
Revert specifying `ncu` for non-ncu command

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -286,7 +286,7 @@ function printUpgrades(args) {
         }, {
             greatest: options.greatest
         });
-        print((numUnsatisfied > 0 ? '\n' : '') + 'The following dependenc' + (numSatisfied === 1 ? 'y is' : 'ies are') + ' satisfied by ' + (numSatisfied === 1 ? 'its' : 'their') + ' declared version range, but the installed version' + (numSatisfied === 1 ? ' is' : 's are') + ' behind. You can install the latest version' + (numSatisfied === 1 ? '' : 's') + ' without modifying your package file by using ' + chalk.cyan('ncu ') + chalk.blue(options.packageManager + ' update') + '. If you want to update the dependenc' + (numSatisfied === 1 ? 'y' : 'ies') + ' in your package file anyway, use ' + chalk.cyan('ncu ') + chalk.blue('-a/--upgradeAll') + '.\n');
+        print((numUnsatisfied > 0 ? '\n' : '') + 'The following dependenc' + (numSatisfied === 1 ? 'y is' : 'ies are') + ' satisfied by ' + (numSatisfied === 1 ? 'its' : 'their') + ' declared version range, but the installed version' + (numSatisfied === 1 ? ' is' : 's are') + ' behind. You can install the latest version' + (numSatisfied === 1 ? '' : 's') + ' without modifying your package file by using ' + chalk.blue(options.packageManager + ' update') + '. If you want to update the dependenc' + (numSatisfied === 1 ? 'y' : 'ies') + ' in your package file anyway, use ' + chalk.cyan('ncu ') + chalk.blue('-a/--upgradeAll') + '.\n');
         print(satisfiedTable.toString());
     }
 


### PR DESCRIPTION
Fixes the mistake introduced in #255 (explained [here](https://github.com/tjunnone/npm-check-updates/pull/255#issuecomment-233529203)).