### PR TITLE
eslint fix

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -52,9 +52,12 @@
                 "named": "never"
             }
         ],
-        "space-after-keywords": [
+        "keyword-spacing": [
             2,
-            "always"
+            {
+                "before": true,
+                "after": true
+            }
         ],
         "operator-linebreak": [
             2,

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -299,19 +299,19 @@ function getLatestVersions(packageMap, options) {
 
     // determine the getPackageVersion function from options.versionTarget
     switch (options.versionTarget) {
-        case('latest'):
+        case ('latest'):
             getPackageVersion = selectedPackageManager.latest;
             break;
-        case('greatest'):
+        case ('greatest'):
             getPackageVersion = selectedPackageManager.greatest;
             break;
-        case('newest'):
+        case ('newest'):
             getPackageVersion = selectedPackageManager.newest;
             break;
-        case('major'):
+        case ('major'):
             getPackageVersion = selectedPackageManager.greatestMajor;
             break;
-        case('minor'):
+        case ('minor'):
             getPackageVersion = selectedPackageManager.greatestMinor;
             break;
         default:


### PR DESCRIPTION
Changed deprecated rule [`space-after-keywords`](http://eslint.org/docs/rules/space-after-keywords) for [`keyword-spacing`](http://eslint.org/docs/rules/keyword-spacing)