### PR TITLE
Fix Windows global prefix not set

### DIFF
--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -66,6 +66,13 @@ module.exports = {
             if (args.global && npm.config.get('prefix').match('Cellar')) {
                 npm.config.set('prefix', '/usr/local');
             }
+
+            // Workaround: set prefix on windows for global packages
+            // Only needed when using npm api directly
+            if (process.platform === 'win32' && npm.config.get('global') && !process.env.prefix) {
+                npm.config.set('prefix', process.env.AppData + '\\npm');
+            }
+
             return initialized = true;
         });
     },


### PR DESCRIPTION
Sets prefix manually to %AppData%\npm on windows in global mode. Fixes https://github.com/tjunnone/npm-check-updates/issues/163.