### PR TITLE
Fixes npm ENOENT error on Windows.

### DIFF
--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -91,7 +91,7 @@ module.exports = {
 
         // if packageFile is specified, spawn an npm process so that installed modules can be read from the same directotry as the package file (#201)
         return options.cwd ?
-            spawn('npm', ['ls', '--json', '-depth=0'], {cwd: options.cwd})
+            spawn(process.platform === 'win32'? 'npm.cmd' : 'npm', ['ls', '--json', '-depth=0'], {cwd: options.cwd})
                 .then(JSON.parse)
                 // transform results into a similar format as the API
                 .then(function (results) {


### PR DESCRIPTION
Windows requires spawn to execute npm with the .cmd extension.
Fixes https://github.com/tjunnone/npm-check-updates/issues/301