### PR TITLE
[WIP] Remove version ranges from final version based on flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Do not use these unless you know what you are doing! Not needed for typical usag
                              latest stable versions
     -a, --upgradeAll         include even those dependencies whose latest
                              version satisfies the declared semver dependency
+    --removeRange            remove version ranges from the final package version
 
 Integration
 --------------

--- a/bin/ncu
+++ b/bin/ncu
@@ -35,7 +35,8 @@ program
     .option('-u, --upgrade', 'overwrite package file')
     .option('-x, --reject <matches>', 'exclude packages matching the given string, comma-delimited list, or regex')
     .option('-a, --upgradeAll', 'include even those dependencies whose latest version satisfies the declared semver dependency')
-    .option('--semverLevel <level>', 'find the highest version within "major" or "minor"');
+    .option('--semverLevel <level>', 'find the highest version within "major" or "minor"')
+    .option('--removeRange', 'remove version ranges from the final package version');
 
 program.parse(process.argv);
 

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -124,7 +124,9 @@ function upgradePackageDefinitions(currentDependencies) {
         registry: options.registry ? options.registry : null
     }).then(function (latestVersions) {
 
-        var upgradedDependencies = vm.upgradeDependencies(currentDependencies, latestVersions);
+        var upgradedDependencies = vm.upgradeDependencies(currentDependencies, latestVersions, {
+            removeRange: options.removeRange
+        });
 
         var filteredUpgradedDependencies = _.pickBy(upgradedDependencies, function (v, dep) {
             return !options.jsonUpgraded || options.upgradeAll || !vm.isSatisfied(latestVersions[dep], currentDependencies[dep]);

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -92,11 +92,15 @@ function upgradeDependencyDeclaration(declaration, latestVersion, options) {
     var isLessThan = uniqueOperators[0] === '<' || uniqueOperators[0] === '<=';
     var isMixed = uniqueOperators.length > 1;
 
-    // convert versions with </<= or mixed operators into the preferred wildcard
-    // only do so if the new version does not already contain a wildcard
-    return !hasWildCard && (isLessThan || isMixed) ?
-        versionUtil.addWildCard(version, options.wildcard) :
-        operator + version;
+    if (options.removeRange) {
+        return latestVersion;
+    } else {
+        // convert versions with </<= or mixed operators into the preferred wildcard
+        // only do so if the new version does not already contain a wildcard
+        return !hasWildCard && (isLessThan || isMixed) ?
+            versionUtil.addWildCard(version, options.wildcard) :
+            operator + version;
+    }
 }
 
 /**
@@ -105,7 +109,7 @@ function upgradeDependencyDeclaration(declaration, latestVersion, options) {
  * @param latestVersions latest available versions collection object
  * @returns {{}} upgraded dependency collection object
  */
-function upgradeDependencies(currentDependencies, latestVersions) {
+function upgradeDependencies(currentDependencies, latestVersions, options) {
 
     // filter out dependencies with empty values
     currentDependencies = cint.filterObject(currentDependencies, function (key, value) {
@@ -115,7 +119,8 @@ function upgradeDependencies(currentDependencies, latestVersions) {
     // get the preferred wildcard and bind it to upgradeDependencyDeclaration
     var wildcard = getPreferredWildcard(currentDependencies) || DEFAULT_WILDCARD;
     var upgradeDep = _.partialRight(upgradeDependencyDeclaration, {
-        wildcard: wildcard
+        wildcard: wildcard,
+        removeRange: options.removeRange
     });
 
     return _(currentDependencies)

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -111,6 +111,8 @@ function upgradeDependencyDeclaration(declaration, latestVersion, options) {
  */
 function upgradeDependencies(currentDependencies, latestVersions, options) {
 
+    options = options || {};
+
     // filter out dependencies with empty values
     currentDependencies = cint.filterObject(currentDependencies, function (key, value) {
         return value;

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -36,15 +36,17 @@ function upgradeDependencyDeclaration(declaration, latestVersion, options) {
     options = options || {};
     options.wildcard = options.wildcard || DEFAULT_WILDCARD;
 
-    // return global versionUtil.wildcards immediately
-    if (versionUtil.isWildCard(declaration)) {
-        return declaration;
-    }
-
     // parse the latestVersion
     // return original declaration if latestSemver is invalid
     var latestSemver = semverutils.parseRange(latestVersion)[0];
     if (!latestSemver) {
+        return declaration;
+    }
+
+    // return global versionUtil.wildcards immediately
+    if (options.removeRange) {
+        return latestVersion;
+    } else if (versionUtil.isWildCard(declaration)) {
         return declaration;
     }
 
@@ -92,15 +94,11 @@ function upgradeDependencyDeclaration(declaration, latestVersion, options) {
     var isLessThan = uniqueOperators[0] === '<' || uniqueOperators[0] === '<=';
     var isMixed = uniqueOperators.length > 1;
 
-    if (options.removeRange) {
-        return latestVersion;
-    } else {
-        // convert versions with </<= or mixed operators into the preferred wildcard
-        // only do so if the new version does not already contain a wildcard
-        return !hasWildCard && (isLessThan || isMixed) ?
-            versionUtil.addWildCard(version, options.wildcard) :
-            operator + version;
-    }
+    // convert versions with </<= or mixed operators into the preferred wildcard
+    // only do so if the new version does not already contain a wildcard
+    return !hasWildCard && (isLessThan || isMixed) ?
+        versionUtil.addWildCard(version, options.wildcard) :
+        operator + version;
 }
 
 /**

--- a/test/test-versionmanager.js
+++ b/test/test-versionmanager.js
@@ -100,6 +100,11 @@ describe('versionmanager', function () {
             vm.upgradeDependencyDeclaration("1.0", "").should.equal("1.0");
             vm.upgradeDependencyDeclaration("1.0", null).should.equal("1.0");
         });
+
+        it('should remove semver range if removeRange option is specified', function () {
+            vm.upgradeDependencyDeclaration("^1.0.0", "1.0.1", { removeRange: true }).should.equal("1.0.1");
+            vm.upgradeDependencyDeclaration("2.2.*", "3.1.1", { removeRange: true }).should.equal("3.1.1");
+        });
     });
 
     describe('updatePackageData', function () {


### PR DESCRIPTION
Fixes #313.

@raineorshine I'm not sure if this (https://github.com/tjunnone/npm-check-updates/pull/314/files#diff-15ec6f0a7089133029d1784f738d3a27R95) is the right place to skip the range addition to the final version. 