### PR TITLE
Fix --silent option regression

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -346,7 +346,7 @@ function programInit() {
         .some(_.propertyOf(options));
 
     // convert silent option to loglevel silent
-    if (!options.loglevel && options.silent) {
+    if (options.silent) {
         options.loglevel = 'silent';
     }
 }

--- a/test/test-ncu.js
+++ b/test/test-ncu.js
@@ -212,12 +212,20 @@ describe('npm-check-updates', function () {
                     pkgData.should.not.have.property('chalk');
                 });
         });
+
         it('should update only packages which have new patch versions', function () {
             return spawn('node', ['bin/ncu', '--jsonUpgraded', '--semverLevel', 'minor'], '{ "dependencies": { "express": "2.4.1", "chalk": "^0.1.0" } }')
                 .then(JSON.parse)
                 .then(function (pkgData) {
                     pkgData.express.should.equal('2.4.7');
                     pkgData.should.not.have.property('chalk');
+                });
+        });
+
+        it('should suppress stdout when --silent is provided', function() {
+            return spawn('node', ['bin/ncu', '--silent'], '{ "dependencies": { "express": "1" } }')
+                .then(function (output) {
+                    output.trim().should.equal('')
                 });
         });
     });


### PR DESCRIPTION
Possible fix for #317. 

Two points I want to ask:

1. The current fix will override `loglevel` option when the `silent` option is provided. I think this is how it should work. But not sure if the `!options.loglevel` check was given there for a specific reason. What do you think?

2. How do we test if the silent option is set correctly? Just to make sure this doesn't break in the future again.