### PR TITLE
fallback to package.json when stdin closed with no content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ npm-debug.log
 node_modules
 
 .idea
+*.iml

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -378,6 +378,7 @@ function programRunLocal() {
         pkgData = Promise.resolve(options.packageData);
     } else if (options.packageFile) {
         pkgFile = options.packageFile;
+        pkgData = getPackageDataFromFile(pkgFile, pkgFileName);
     } else if (!process.stdin.isTTY) {
         print('Waiting for package data on stdin...', 'verbose');
 
@@ -387,37 +388,42 @@ function programRunLocal() {
             console.log(stdinWarningMessage);
         }, stdinWarningTime);
 
-        pkgData = getstdin();
-
-        // clear the warning timer once stdin returns
-        pkgData.then(function () {
+        // clear the warning timer once stdin returns and fallback to scanning pwd if no content from stdin
+        pkgData = getstdin().then(function (_pkgData) {
             clearTimeout(stdinTimer);
+
+            var isEmptyStdin = _pkgData.length === 0 || (_pkgData.length === 1 && _pkgData.charCodeAt(0) === 10);
+            // if no stdin content fall back to searching for package.json from pwd and up to root
+            if (isEmptyStdin) {
+                pkgFile = findUp.sync(pkgFileName);
+                return getPackageDataFromFile(pkgFile, pkgFileName);
+            } else {
+                return _pkgData;
+            }
         });
     } else {
         // find the closest package starting from the current working directory and going up to the root
         pkgFile = findUp.sync(pkgFileName);
+        pkgData = getPackageDataFromFile(pkgFile, pkgFileName);
     }
 
-    // if pkgFile was set, make sure it exists and read it into pkgData
-    if (pkgFile) {
-        // print a message if we are using a descendant package file
-        var relPathToPackage = path.resolve(pkgFile);
-        if (relPathToPackage !== pkgFileName) {
-            print('Using ' + relPathToPackage);
-        }
-        if (!fs.existsSync(pkgFile)) {
-            programError(chalk.red(relPathToPackage + ' not found'));
-        }
+    return pkgData.then(function (_pkgData) {
+        print('wtf', _pkgData);
+        return analyzeProjectDependencies(_pkgData, pkgFile);
+    });
+}
 
-        pkgData = readPackageFile(pkgFile, null, false);
+function getPackageDataFromFile(pkgFile, pkgFileName) {
+    // print a message if we are using a descendant package file
+    var relPathToPackage = path.resolve(pkgFile);
+    if (relPathToPackage !== pkgFileName) {
+        print('Using ' + relPathToPackage);
+    }
+    if (!fs.existsSync(pkgFile)) {
+        programError(chalk.red(relPathToPackage + ' not found'));
     }
 
-    // no package data!
-    if (!pkgData) {
-        programError(chalk.red('No ' + pkgFileName) + '\n\nPlease add a ' + pkgFileName + ' to the current directory, specify the ' + chalk.blue('--packageFile') + ' or ' + chalk.blue('--packageData') + ' options, or pipe a ' + pkgFileName + ' to stdin.');
-    }
-
-    return pkgData.then(_.partial(analyzeProjectDependencies, _, pkgFile));
+    return readPackageFile(pkgFile);
 }
 
 module.exports = _.merge({

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -408,7 +408,6 @@ function programRunLocal() {
     }
 
     return pkgData.then(function (_pkgData) {
-        print('wtf', _pkgData);
         return analyzeProjectDependencies(_pkgData, pkgFile);
     });
 }

--- a/test/test-ncu.js
+++ b/test/test-ncu.js
@@ -3,6 +3,7 @@ var chai            = require("chai");
 var fs              = require('fs');
 var spawn           = require('spawn-please')
 var BluebirdPromise = require('bluebird')
+var child           = require('child_process')
 
 chai.use(require("chai-as-promised"));
 chai.use(require('chai-string'))
@@ -91,6 +92,17 @@ describe('npm-check-updates', function () {
                 .then(function (output) {
                     output.trim().should.startWith('express')
                 });
+        });
+
+        it('should fall back to package.json search when receiving empty content on stdin', function (done) {
+            var childProcess = child.exec('node bin/ncu', function (error, stdout) {
+                if (error) {
+                    throw new Error(error);
+                }
+                stdout.toString().trim().should.match(/^Using .+package.json/);
+                done();
+            });
+            childProcess.stdin.end();
         });
 
         it('should output json with --jsonAll', function() {

--- a/test/test-ncu.js
+++ b/test/test-ncu.js
@@ -97,7 +97,7 @@ describe('npm-check-updates', function () {
         it('should fall back to package.json search when receiving empty content on stdin', function (done) {
             var childProcess = child.exec('node bin/ncu', function (error, stdout) {
                 if (error) {
-                    throw new Error(error);
+                    done(error);
                 }
                 stdout.toString().trim().should.match(/^Using .+package.json/);
                 done();


### PR DESCRIPTION
I'm making this change to with #119 

The change is to support a parent process starting ncu with child_process, closing stdin without piping package.json content and having ncu fallback to search for package.json from fs.