### PR TITLE
adding --timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Do not use these unless you know what you are doing! Not needed for typical usag
     -a, --upgradeAll         include even those dependencies whose latest
                              version satisfies the declared semver dependency
     --removeRange            remove version ranges from the final package version
+    --timeout                a global timeout in ms
 
 Integration
 --------------

--- a/bin/ncu
+++ b/bin/ncu
@@ -31,7 +31,7 @@ program
     .option('-r, --registry <url>', 'specify third-party npm registry')
     .option('-s, --silent', "don't output anything (--loglevel silent)")
     .option('-t, --greatest', 'find the highest versions available instead of the latest stable versions')
-    .option('--timeout <seconds>', 'set a global timeout in ms')
+    .option('--timeout <seconds>', 'a global timeout in ms')
     .option('-u, --upgrade', 'overwrite package file')
     .option('-x, --reject <matches>', 'exclude packages matching the given string, comma-delimited list, or regex')
     .option('-a, --upgradeAll', 'include even those dependencies whose latest version satisfies the declared semver dependency')

--- a/bin/ncu
+++ b/bin/ncu
@@ -31,6 +31,7 @@ program
     .option('-r, --registry <url>', 'specify third-party npm registry')
     .option('-s, --silent', "don't output anything (--loglevel silent)")
     .option('-t, --greatest', 'find the highest versions available instead of the latest stable versions')
+    .option('--timeout <seconds>', 'set a global timeout in ms')
     .option('-u, --upgrade', 'overwrite package file')
     .option('-x, --reject <matches>', 'exclude packages matching the given string, comma-delimited list, or regex')
     .option('-a, --upgradeAll', 'include even those dependencies whose latest version satisfies the declared semver dependency')

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -450,9 +450,24 @@ function run(opts) {
 
         options = initOptions(options);
 
-        return options.global ?
+        if (options.timeout) {
+            var timeoutMs = _.isString(options.timeout) ? parseInt(options.timeout, 10) : options.timeout;
+            var timeout = setTimeout(function () {
+                programError(options, chalk.red('Exceeded global timeout of ' + timeoutMs + 'ms'));
+            }, timeoutMs);
+        }
+
+        var pendingAnalysis = options.global ?
             analyzeGlobalPackages(options) :
             findPackage(options).spread(_.partial(analyzeProjectDependencies, options));
+
+        if (timeout) {
+            pendingAnalysis = pendingAnalysis.then(function () {
+                clearTimeout(timeout);
+            });
+        }
+
+        return pendingAnalysis;
     });
 }
 

--- a/test/test-ncu.js
+++ b/test/test-ncu.js
@@ -242,6 +242,23 @@ describe('npm-check-updates', function () {
                     output.trim().should.equal('');
                 });
         });
+
+        describe('with timeout option', function () {
+
+            it('should exit with error when timeout exceeded', function (done) {
+                spawn('node', ['bin/ncu', '--timeout', '1'], '{ "dependencies": { "express": "1" } }')
+                    .then(function () {
+                        done(new Error('should not resolve'));
+                    }).catch(function (stderr) {
+                        stderr.should.contain('Exceeded global timeout of 1ms');
+                        done();
+                    });
+            });
+
+            it('completes successfully with timeout', function () {
+                return spawn('node', ['bin/ncu', '--timeout', '100000'], '{ "dependencies": { "express": "1" } }');
+            });
+        });
     });
 
 });


### PR DESCRIPTION
In a new test I used done() from a callback to have cleaner error handling/output when an error is expected but the spawn finishes successfully. It felt dirtier having the .catch() have to check if it was the error we expect or another error.