### PR TITLE
Object.assign -> _.assign for backwards compat.

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -310,7 +310,7 @@ function printUpgrades(options, args) {
 /** Initializes and consolidates options from the cli. */
 function initOptions(options) {
 
-    return Object.assign({}, options, {
+    return _.assign({}, options, {
         // 'upgradeAll' is a type of an upgrade so if it's set, we set 'upgrade' as well
         upgrade: options.upgrade || options.upgradeAll,
         // convert silent option to loglevel silent
@@ -471,6 +471,6 @@ function run(opts) {
     });
 }
 
-module.exports = Object.assign({
+module.exports = _.assign({
     run: run
 }, vm);


### PR DESCRIPTION
[`Object.assign` is not available in node v0.12.x](http://node.green/#ES2015-built-in-extensions-Object-static-methods), which is listed as this project's minimum required engine.