### PR TITLE
Fix Jest bug by replacing require-dir with static dependencies

### DIFF
--- a/lib/package-managers/index.js
+++ b/lib/package-managers/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+    bower: require('./bower'),
+    npm: require('./npm')
+};

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -5,7 +5,7 @@ var semverutils = require('semver-utils');
 var Promise = require('bluebird');
 var versionUtil = require('./version-util.js');
 var requireDir = require('require-dir');
-var packageManagers = requireDir('./package-managers');
+var packageManagers = requireDir(__dirname + '/package-managers');
 
 // keep order for setPrecision
 var DEFAULT_WILDCARD = '^';

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -4,8 +4,7 @@ var cint = require('cint');
 var semverutils = require('semver-utils');
 var Promise = require('bluebird');
 var versionUtil = require('./version-util.js');
-var requireDir = require('require-dir');
-var packageManagers = requireDir(__dirname + '/package-managers');
+var packageManagers = require('./package-managers');
 
 // keep order for setPrecision
 var DEFAULT_WILDCARD = '^';

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "node-alias": "^1.0.4",
     "npm": "^3.10.6",
     "npmi": "^2.0.1",
-    "require-dir": "^0.3.2",
     "semver": "^5.3.0",
     "semver-utils": "^1.1.1",
     "snyk": "^1.25.1",

--- a/test/individual/test-package-managers.js
+++ b/test/individual/test-package-managers.js
@@ -1,5 +1,4 @@
-var requireDir = require('require-dir');
-var packageManagers = requireDir('../../lib/package-managers');
+var packageManagers = require('../../lib/package-managers');
 var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2586,10 +2586,6 @@ request@^2.79.0:
     tunnel-agent "~0.4.1"
     uuid "^3.0.0"
 
-require-dir@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/require-dir/-/require-dir-0.3.2.tgz#c1d5c75e9fbffde9f2e6b33e383db4f594b5a6a9"
-
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"


### PR DESCRIPTION
This library currently cannot be used in Jest due to #393. This is because our dependency of `require-dir` relies on `module.parent`, which is unsupported in Jest. By replacing `require-dir` we fix this bug which allows dependents to use Jest, get better performance, make ES6 module transitions easier, and we get a statically analyzable require structure allowing for advanced module optimizations in the future (especially in ES6 modules and module loaders like Webpack or Rollup).

If you have a project using `npm-check-updates` in a Jest test, you can `npm install nickmccurdy/npm-check-updates#393` to use my fork temporarily.