### PR TITLE
Fix minor documentation comment typo

### DIFF
--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -316,7 +316,7 @@ function getInstalledPackages(options) {
 /**
  * Get the latest or greatest versions from the NPM repository based on the version target
  * @param packageMap   an object whose keys are package name and values are current versions
- * @param options       Options. Default: { versionTarget: 'latest' }. You may also specify { versionTarge: 'greatest' }
+ * @param options       Options. Default: { versionTarget: 'latest' }. You may also specify { versionTarget: 'greatest' }
  * @returns             Promised {packageName: version} collection
  */
 function queryVersions(packageMap, options) {


### PR DESCRIPTION
`versionTarge` ➡️ `versionTarget`