### PR TITLE
Upgrade global packages through subshell

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -127,11 +127,6 @@ var writePackageFile = fs.writeFileAsync;
 
 function analyzeGlobalPackages(options) {
 
-    if (options.global && options.upgrade) {
-        programError(options, chalk.cyan('ncu') + ' cannot upgrade global packages. Run ' + chalk.cyan('npm install -g [package]') +
-            ' to update a global package');
-    }
-
     print(options, 'Getting installed packages...', 'verbose');
 
     return vm.getInstalledPackages({
@@ -145,6 +140,12 @@ function analyzeGlobalPackages(options) {
 
             return vm.upgradePackageDefinitions(globalPackages, options)
                 .spread(function (upgraded, latest) {
+
+                    if (options.global && options.upgrade) {
+                        var instruction = Object.keys(upgraded).join(' ') || '[package]';
+                        programError(options, chalk.cyan('ncu') + ' cannot upgrade global packages. Run ' + chalk.cyan('npm install -g ' + instruction) +
+                            ' to update a global package');
+                    }
 
                     print(options, latest, 'silly');
                     printUpgrades(options, {


### PR DESCRIPTION
Hopefully this is a problem other people share and this PR will be useful.

Given a machine in this state

```
$ ncu -g
 image-to-ascii-cli   1.0.7  →   1.0.8
 jest-codemods       0.13.3  →  0.13.4
 js-beautify         1.6.14  →   1.7.4
 lebab                2.7.5  →   2.7.7
 npm-check-updates   2.12.1  →  2.13.0
 nsp                  2.7.0  →   2.8.1
 prepack              0.2.6  →   0.2.8
 prettier             1.6.1  →   1.7.4
 rimraf               2.6.1  →   2.6.2
```

When running `ncu -ug` the following output is displayed

```
ncu cannot upgrade global packages. Run npm install -g [package] to update a global package
```

This PR would result in the following output being displayed when running `ncu -ug` and upgrades are available

```
ncu cannot upgrade global packages. Run npm install -g image-to-ascii-cli jest-codemods js-beautify lebab npm-check-updates nsp prepack prettier rimraf to update a global package
```

...or the original message if no upgrades are available

```
ncu cannot upgrade global packages. Run npm install -g [package] to update a global package
```

The reason for this request is that it would let me copy the install message and run it to install all global dependencies at once. At the moment I have to run `ncu -g` then copy and edit the output to construct this install command.

The linter and tests are passing.

Thanks a lot for this really useful tool.