### PR TITLE
Removed message asking to run ncu -a when it just run

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -281,7 +281,9 @@ function printUpgrades(options, args) {
             greatest: options.greatest,
             newest: options.newest
         });
-        print(options, (numUnsatisfied > 0 ? '\n' : '') + 'The following dependenc' + (numSatisfied === 1 ? 'y is' : 'ies are') + ' satisfied by ' + (numSatisfied === 1 ? 'its' : 'their') + ' declared version range, but the installed version' + (numSatisfied === 1 ? ' is' : 's are') + ' behind. You can install the latest version' + (numSatisfied === 1 ? '' : 's') + ' without modifying your package file by using ' + chalk.cyan(options.packageManager + ' update') + '. If you want to update the dependenc' + (numSatisfied === 1 ? 'y' : 'ies') + ' in your package file anyway, run ' + chalk.cyan('ncu -a') + '.\n', 'warn');
+        if (!options.upgrade) {
+            print(options, (numUnsatisfied > 0 ? '\n' : '') + 'The following dependenc' + (numSatisfied === 1 ? 'y is' : 'ies are') + ' satisfied by ' + (numSatisfied === 1 ? 'its' : 'their') + ' declared version range, but the installed version' + (numSatisfied === 1 ? ' is' : 's are') + ' behind. You can install the latest version' + (numSatisfied === 1 ? '' : 's') + ' without modifying your package file by using ' + chalk.cyan(options.packageManager + ' update') + '. If you want to update the dependenc' + (numSatisfied === 1 ? 'y' : 'ies') + ' in your package file anyway, run ' + chalk.cyan('ncu -a') + '.\n', 'warn');
+        }
         print(options, satisfiedTable.toString(), 'warn');
     }
 


### PR DESCRIPTION
After running ncu -a the message 

> The following dependencies are satisfied by their declared version range, but the installed versions are behind. You can install the latest versions without modifying your package file by using npm update. If you want to update the dependencies in your package file anyway, run ncu -a.

appears again as shown in the image below

![ncu-before](https://user-images.githubusercontent.com/827278/32538491-db1e630e-c46e-11e7-9055-5b40c13e1bca.png)

I believe that this should not be the case, since I just ran ncu -a and I just want to see what has changed in my package files (not be prompted to run it again), as shown in the image below

![ncu-after](https://user-images.githubusercontent.com/827278/32538493-dcd76ff6-c46e-11e7-8ea9-0ac99849ff91.png)
