### PR TITLE
Added support for .ncurc config files using rc-config-loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ node_modules
 .idea
 *.iml
 yarn.lock
+.DS_store

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ ncu '/^(?!gulp-).*$/'
 
 Options
 --------------
-    -f, --filter             include only package names matching the given string, 
+    -f, --filter             include only package names matching the given string,
                              comma-delimited list, or regex
     -g, --global             check global packages instead of in the current project
     -h, --help               output usage information
@@ -93,14 +93,16 @@ Do not use these unless you know what you are doing! Not needed for typical usag
     -j, --jsonAll            output new package file instead of human-readable
                              message
     --jsonUpgraded           output upgraded dependencies in json
-    -l, --loglevel           what level of logs to report: silent, error, warn, 
+    -l, --loglevel           what level of logs to report: silent, error, warn,
                              info, verbose, silly (default: warn)
     -p, --prod               check only dependencies (not devDependencies)
     --packageData            include stringified package file (use stdin instead)
     --packageFile            package file location (default: ./package.json)
-    --packageFileDir         use same directory as packageFile to compare against 
+    --packageFileDir         use same directory as packageFile to compare against
                              installed modules. See #201.
-    -n, --newest             find the newest published versions available instead 
+    --configFilePath         rc config file path (default: ./)
+    --configFileName         rc config file name (default: .ncurc.{json,yml,js})                             
+    -n, --newest             find the newest published versions available instead
                              of the latest stable versions
     -o, --optional           check only optionalDependencies
     --peer                   check only peerDependencies
@@ -112,6 +114,12 @@ Do not use these unless you know what you are doing! Not needed for typical usag
                              version satisfies the declared semver dependency
     --removeRange            remove version ranges from the final package version
     --timeout                a global timeout in ms
+
+Configuration Files
+--------------
+Use a `.ncurc.{json,yml,js}` file to specify configuration information.
+You can specify file name and path using `--configFilePath` and `--configFilePath`
+command line options.
 
 Integration
 --------------
@@ -155,7 +163,7 @@ How dependency updates are determined
 
 Why is it not updating ^1.0.0 to ^1.0.1 when 1.0.1 is the latest?
 --------------
-`^1.0.0` is a *range* that will includes all non-major updates. If you run `npm update`, it will install `1.0.1` without changing the dependency listed in your package file. You don't need to update your package file if the latest version is satisfied by the specified dependency range. If you *really* want to upgrade your package file (even though it's not necessary), you can run `ncu --upgradeAll`. 
+`^1.0.0` is a *range* that will includes all non-major updates. If you run `npm update`, it will install `1.0.1` without changing the dependency listed in your package file. You don't need to update your package file if the latest version is satisfied by the specified dependency range. If you *really* want to upgrade your package file (even though it's not necessary), you can run `ncu --upgradeAll`.
 
 Docker
 ------
@@ -173,7 +181,7 @@ Known Issues
 
 - In some environments (Windows) npm-check-updates may hang. Run `ncu --loglevel verbose` to see if it is waiting for stdin. If so, try setting the package file explicitly: `ncu -g --packageFile package.json`. See [#136](https://github.com/tjunnone/npm-check-updates/issues/136#issuecomment-155721102).
 
-- There is an issue with [grunt-shell](https://github.com/sindresorhus/grunt-shell) described in [#119](https://github.com/tjunnone/npm-check-updates/issues/119). TLDR; You have to explicitly specify your package file with `ncu --packageFile package.json`. 
+- There is an issue with [grunt-shell](https://github.com/sindresorhus/grunt-shell) described in [#119](https://github.com/tjunnone/npm-check-updates/issues/119). TLDR; You have to explicitly specify your package file with `ncu --packageFile package.json`.
 
 - `Cannot find module 'proto-list'`. This error is occurring for many people, yet it cannot be consistently reproduced. It seems to be fixed by fresh installs of node and npm: "I reinstalled node 4.2.1 and npm 2.14.7. Installed ncu, and it worked fine. So I'm afraid I'm not able to reproduce the issue anymore." See [#144](https://github.com/tjunnone/npm-check-updates/issues/144#issuecomment-148499121).
 

--- a/bin/ncu
+++ b/bin/ncu
@@ -3,6 +3,8 @@
 var program = require('commander');
 var updateNotifier = require('update-notifier');
 var cint = require('cint');
+var _ = require('lodash');
+var rcLoader = require('rc-config-loader');
 var ncu = require('../lib/npm-check-updates');
 var pkg = require('../package.json');
 
@@ -30,6 +32,8 @@ program
     .option('-p, --prod', 'check only dependencies (not devDependencies)')
     .option('--peer', 'check only peerDependencies')
     .option('-r, --registry <url>', 'specify third-party npm registry')
+    .option('--configFilePath <path>', 'rc config file path (default: ./)')
+    .option('--configFileName <path>', 'rc config file name (default: .ncurc.{json,yml,js})')
     .option('-s, --silent', "don't output anything (--loglevel silent)")
     .option('-t, --greatest', 'find the highest versions available instead of the latest stable versions')
     .option('--timeout <ms>', 'a global timeout in ms')
@@ -42,6 +46,21 @@ program
     .option('-V', '', function() { console.log(pkg.version); process.exit(0); });
 
 program.parse(process.argv);
+
+var rcFile = rcLoader('ncurc', {
+    configFileName: program.configFileName || '.ncurc',
+    defaultExtension: ['.json', '.yml', '.js'],
+    cwd: program.configFilePath || undefined
+});
+
+var rcArguments = rcFile && rcFile.config ?
+    _.flatten(_.map(rcFile.config, function (value, name) {
+        return value === true ? ['--' + name] : ['--' + name, value];
+    })) : [];
+
+var combinedArguments = process.argv.slice(0,2).concat(rcArguments).concat(process.argv.slice(2));
+
+program.parse(combinedArguments);
 
 program.cli = true;
 program.filter = program.args.join(' ') || program.filter;

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "node-alias": "^1.0.4",
     "npm": "^3.10.6",
     "npmi": "^2.0.1",
+    "rc-config-loader": "^2.0.1",
     "semver": "^5.3.0",
     "semver-utils": "^1.1.1",
     "snyk": "^1.25.1",

--- a/test/test-ncu.js
+++ b/test/test-ncu.js
@@ -243,6 +243,51 @@ describe('npm-check-updates', function () {
                 });
         });
 
+        it('should read --configFilePath', function () {
+            var tempFilePath = './test/';
+            var tempFileName = '.ncurc.json';
+            fs.writeFileSync(tempFilePath + tempFileName, '{"jsonUpgraded": true, "filter": "express"}', 'utf-8');
+            return spawn('node', ['bin/ncu', '--configFilePath', tempFilePath], '{ "dependencies": { "express": "1", "chalk": "0.1.0" } }')
+                .then(JSON.parse)
+                .then(function (pkgData) {
+                    pkgData.should.have.property('express');
+                    pkgData.should.not.have.property('chalk');
+                })
+                .finally(function () {
+                    fs.unlinkSync(tempFilePath + tempFileName);
+                });
+        });
+
+        it('should read --configFileName', function () {
+            var tempFilePath = './test/';
+            var tempFileName = '.rctemp.json';
+            fs.writeFileSync(tempFilePath + tempFileName, '{"jsonUpgraded": true, "filter": "express"}', 'utf-8');
+            return spawn('node', ['bin/ncu', '--configFilePath', tempFilePath, '--configFileName', tempFileName], '{ "dependencies": { "express": "1", "chalk": "0.1.0" } }')
+                .then(JSON.parse)
+                .then(function (pkgData) {
+                    pkgData.should.have.property('express');
+                    pkgData.should.not.have.property('chalk');
+                })
+                .finally(function () {
+                    fs.unlinkSync(tempFilePath + tempFileName);
+                });
+        });
+
+        it('should override config with arguments', function () {
+            var tempFilePath = './test/';
+            var tempFileName = '.ncurc.json';
+            fs.writeFileSync(tempFilePath + tempFileName, '{"jsonUpgraded": true, "filter": "express"}', 'utf-8');
+            return spawn('node', ['bin/ncu', '--configFilePath', tempFilePath, '--filter', 'chalk'], '{ "dependencies": { "express": "1", "chalk": "0.1.0" } }')
+                .then(JSON.parse)
+                .then(function (pkgData) {
+                    pkgData.should.have.property('chalk');
+                    pkgData.should.not.have.property('express');
+                })
+                .finally(function () {
+                    fs.unlinkSync(tempFilePath + tempFileName);
+                });
+        });
+
         describe('with timeout option', function () {
 
             it('should exit with error when timeout exceeded', function (done) {


### PR DESCRIPTION
* Added  rc-config-loader@2.0.1 (https://github.com/azu/rc-config-loader)

* Reading `.ncurc{.json,.yml,.js}` as documented for rc-config-loader

* Combining parameters read from rc with argv putting them in the beginning of user arguments list so custom arguments will override provided in rc

* P.S. Added `.DS_store` to `.gitignore`