### PR TITLE
fix: asynchronous function printUpgrades now returns a promise

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -147,7 +147,7 @@ function analyzeGlobalPackages(options) {
                 .spread(function (upgraded, latest) {
 
                     print(options, latest, 'silly');
-                    printUpgrades(options, {
+                    return printUpgrades(options, {
                         current: globalPackages,
                         upgraded: upgraded,
                         latest: latest
@@ -207,7 +207,7 @@ function analyzeProjectDependencies(options, pkgData, pkgFile) {
                 printJson(options, JSON.stringify(output));
                 return output;
             } else {
-                printUpgrades(options, {
+                return printUpgrades(options, {
                     installed: installed,
                     current: current,
                     upgraded: upgraded,
@@ -216,7 +216,6 @@ function analyzeProjectDependencies(options, pkgData, pkgFile) {
                     pkgFile: pkgFile,
                     isUpgrade: options.upgrade
                 });
-                return null;
             }
         });
 }
@@ -294,8 +293,8 @@ function printUpgrades(options, args) {
             programError(options, 'Dependencies not up-to-date');
         } else if (args.isUpgrade) {
             var newPkgData = vm.upgradePackageData(args.pkgData, args.current, args.upgraded, args.latest, options);
-            writePackageFile(args.pkgFile, newPkgData)
-                .then(function () {
+            return writePackageFile(args.pkgFile, newPkgData)
+                .then(function (res) {
                     print(options, 'Upgraded ' + args.pkgFile + '\n');
                 });
         } else {
@@ -304,6 +303,7 @@ function printUpgrades(options, args) {
     }
 
     print(options, '');
+    return Promise.resolve();
 }
 
 //


### PR DESCRIPTION
resolves #378 

Looks like printUpgrades function uses async function `writeFileAsync`. I've changed printUpgrades to return a promise now which resolves the reported  issue and looks to have no side-effects.

I think there's a fair bit of refactoring that could happen around this function, so let me know if 
 you'd like any further changes or help 🙂