### PR TITLE
Ignore package if npm view returns error

### DIFF
--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -21,7 +21,7 @@ function view(packageName, field) {
     return npm.commands.viewAsync([packageName, field], true)
         .catch(function (err) {
             // normalize 404 errors
-            throw err.statusCode === 404 ? new Error(404) : err;
+            throw err.statusCode === 404 || err.message.indexOf('404 Not Found') > 0 ? new Error(404) : err;
         })
         .then(function (response) {
 


### PR DESCRIPTION
If I have a dependency kind of 
`"some-dep": "git+ssh://git@git.my-own-local-repo.com/fd/some-project.git#some-branch",`, then `ncu` crashed with this error:
```npm ERR! registry error parsing json
Unhandled rejection SyntaxError: Unexpected token < in JSON at position 0
<html>
<head><title>404 Not Found</title></head>
<body bgcolor="white">
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>

    at JSON.parse (<anonymous>)
    at CachingRegistryClient.<anonymous> (/var/lib/jenkins/workspace/frontend/some-project/node_modules/npm/node_modules/npm-registry-client/lib/request.js:237:23)
    at /var/lib/jenkins/workspace/frontend/some-project/node_modules/npm/node_modules/npm-registry-client/lib/request.js:216:7
    at Gunzip.onEnd (zlib.js:131:5)
    at emitNone (events.js:111:20)
    at Gunzip.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1056:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

The same error I get when adding a nonexistent dependency. 

In these cases  `npm.commands.viewAsync` returns an error without field statusCode, only with message and stackTrace and catch function can't correctly handle it.
