### PR TITLE
Add support for ssl npmrc configurations

### DIFF
--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -6,6 +6,22 @@ const Promise = require('bluebird');
 const versionUtil  = require('../version-util.js');
 const spawn        = require('spawn-please');
 const packageJson  = require('package-json');
+const npmConf      = require('npm-conf')();
+const {Agent: HttpAgent} = require('http');
+const {Agent: HttpsAgent} = require('https');
+
+const httpAgentOptions = {
+    keepAlive: true,
+    maxSockets: npmConf.get('maxsockets')
+};
+const httpsAgentOptions = Object.assign({
+    ca: npmConf.get('ca'),
+    key: npmConf.get('key'),
+    cert: npmConf.get('cert'),
+    rejectUnauthorized: npmConf.get('strict-ssl')
+}, httpAgentOptions);
+const httpAgent = new HttpAgent(httpAgentOptions);
+const httpsAgent = new HttpsAgent(httpsAgentOptions);
 
 const {getProxyAgent} = require('./npm-proxy');
 
@@ -39,6 +55,11 @@ function view(packageName, field, currentVersion) {
     const proxyAgent = getProxyAgent(scope);
     if (proxyAgent) {
         options.agent = proxyAgent;
+    } else {
+        options.agent = {
+            http: httpAgent,
+            https: httpsAgent
+        };
     }
 
     if (field === 'time') {


### PR DESCRIPTION
Fixes https://github.com/tjunnone/npm-check-updates/issues/519#issuecomment-479937779

Can be tested with `.npmrc`

```
registry=https://expired.badssl.com/
strict-ssl=false
```