### PR TITLE
Fix interactive mode prompt - old dependency version shown instead of new

### DIFF
--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -252,7 +252,7 @@ async function upgradePackageData(pkgData, oldDependencies, newDependencies, new
     for (const dependency in newDependencies) {
         if (!options.minimal || !isSatisfied(newVersions[dependency], oldDependencies[dependency])) {
             if (options.interactive) {
-                const to = versionUtil.colorizeDiff(newDependencies[dependency] || '', oldDependencies[dependency]);
+                const to = versionUtil.colorizeDiff(oldDependencies[dependency], newDependencies[dependency] || '');
                 const response = await prompts({
                     type: 'confirm',
                     name: 'value',


### PR DESCRIPTION
This PR fixes a bug in interactive mode prompt which shows "old_version -> old_version" instead of "old_version -> new_version".

Current version 3.5.3 can be upgraded to 3.5.4:
```
radko@radko npm-check-updates $ ncu
Checking ........./npm-check-updates/package.json
[====================] 35/35 100%
bluebird        ^3.5.3  →    ^3.5.4
...
```

But then:
```
radko@radko npm-check-updates $ ncu -i
Checking ........./npm-check-updates/package.json
[====================] 35/35 100%
✖ Do you want to upgrade: bluebird ^3.5.3 → ^3.5.3? … yes
```

and it should instead be:
`✖ Do you want to upgrade: bluebird ^3.5.3 → ^3.5.4? … yes`