### PR TITLE
Pass protocol into proxy agent instead of secureProxy

### DIFF
--- a/lib/package-managers/npm-proxy.js
+++ b/lib/package-managers/npm-proxy.js
@@ -41,11 +41,10 @@ const noProxyCheck = (scope) => {
 if (proxyUrl) {
     const proxy = global.URL ? new URL(proxyUrl) : url.parse(proxyUrl);
     proxyAgent = new ProxyAgent({
+        protocol: proxy.protocol,
         host: proxy.hostname,
         port: proxy.port,
         auth: global.URL ? proxy.username + (proxy.password ? ':' + proxy.password : '') : proxy.auth,
-        secureProxy: proxy.protocol === 'https:',
-        keepAlive: true,
         maxSockets: npmConf.get('maxsockets'),
         ca: npmConf.get('ca'),
         key: npmConf.get('key'),


### PR DESCRIPTION
The `secureProxy` option is actually not used by `https-proxy-agent`, but instead it decides based on the `protocol`. Without this patch https proxies won't work.

Also `keepAlive` isn't needed.