### PR TITLE
Drop bluebird

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -120,7 +120,8 @@
     },
     "env": {
         "node": true,
-        "mocha": true
+        "mocha": true,
+        "es6": true
     },
     "extends": ["eslint:recommended"]
 }

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -402,38 +402,40 @@ async function run(options={}) {
     print(options, 'Initializing...', 'verbose');
 
     if (options.packageManager === 'npm' && !options.prefix) {
+        // eslint-disable-next-line require-atomic-updates
         options.prefix = await packageManagers.npm.defaultPrefix(options);
     }
 
     let timeout;
-    let timeoutPromise = Promise.resolve();
-
+    let timeoutPromise = new Promise(r => r);
     if (options.timeout) {
         const timeoutMs = _.isString(options.timeout) ? parseInt(options.timeout, 10) : options.timeout;
         timeoutPromise = new Promise((resolve, reject) => {
             timeout = setTimeout(() => {
-                // must catch the error and reject expicitly since we are in a setTimeout
+                // must catch the error and reject explicitly since we are in a setTimeout
+                const error = `Exceeded global timeout of ${timeoutMs}ms`;
+                reject(error);
                 try {
-                    programError(options, chalk.red(`Exceeded global timeout of ${timeoutMs}ms`));
-                } catch (e) {
-                    reject(e);
-                }
+                    programError(options, chalk.red(error));
+                } catch (e) {/* noop */}
             }, timeoutMs);
         });
     }
 
-    let pendingAnalysis = options.global ?
-        analyzeGlobalPackages(options) :
-        findPackage(options).then(([pkgData, pkgFile]) => analyzeProjectDependencies(options, pkgData, pkgFile));
-
-    // let the timeout and pendingAnalysis race
-    return await new Promise((resolve, reject) => {
-        timeoutPromise.catch(reject);
-        pendingAnalysis.then(result => {
+    async function getAnalysis() {
+        if (options.global) {
+            const analysis = await analyzeGlobalPackages(options);
             clearTimeout(timeout);
-            resolve(result);
-        });
-    });
+            return analysis;
+        } else {
+            const [pkgData, pkgFile] = await findPackage(options);
+            const analysis = await analyzeProjectDependencies(options, pkgData, pkgFile);
+            clearTimeout(timeout);
+            return analysis;
+        }
+    }
+
+    return await Promise.race([timeoutPromise, getAnalysis()]);
 }
 
 module.exports = _.assign({

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -8,11 +8,11 @@ const cint = require('cint');
 const path = require('path');
 const findUp = require('find-up');
 const _ = require('lodash');
-const Promise = require('bluebird');
 const getstdin = require('get-stdin');
 const Table = require('cli-table');
 const chalk = require('chalk');
-const fs = Promise.promisifyAll(require('fs'));
+const {promisify} = require('util');
+const fs = require('fs');
 const vm = require('./versionmanager');
 const packageManagers = require('./package-managers');
 const versionUtil = require('./version-util');
@@ -114,8 +114,8 @@ function toDependencyTable(args) {
     return table;
 }
 
-const readPackageFile = cint.partialAt(fs.readFileAsync, 1, 'utf8');
-const writePackageFile = fs.writeFileAsync;
+const readPackageFile = cint.partialAt(promisify(fs.readFile), 1, 'utf8');
+const writePackageFile = promisify(fs.writeFile);
 
 //
 // Main functions
@@ -184,7 +184,7 @@ function analyzeProjectDependencies(options, pkgData, pkgFile) {
 
     print(options, `Fetching ${vm.getVersionTarget(options)} versions...`, 'verbose');
 
-    return vm.upgradePackageDefinitions(current, options).spread(async (upgraded, latest) => {
+    return vm.upgradePackageDefinitions(current, options).then(async ([upgraded, latest]) => {
         const {newPkgData, selectedNewDependencies} = await vm.upgradePackageData(pkgData, current, upgraded, latest, options);
 
         const output = options.jsonAll ? jph.parse(newPkgData) :

--- a/lib/package-managers/bower.js
+++ b/lib/package-managers/bower.js
@@ -1,6 +1,5 @@
 'use strict';
 const cint = require('cint');
-const Promise = require('bluebird');
 const chalk = require('chalk');
 const requireg = require('requireg');
 

--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -2,7 +2,6 @@
 const _ = require('lodash');
 const cint = require('cint');
 const semver = require('semver');
-const Promise = require('bluebird');
 const versionUtil  = require('../version-util.js');
 const spawn        = require('spawn-please');
 const pacote = require('pacote');

--- a/lib/raw-promisify.js
+++ b/lib/raw-promisify.js
@@ -1,6 +1,5 @@
 'use strict';
 const _ = require('lodash');
-const Promise = require('bluebird');
 
 /**
  * For some reason, Promise.promisifyAll does not work on npm.commands :(

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -3,7 +3,6 @@ const semver = require('semver');
 const _ = require('lodash');
 const cint = require('cint');
 const semverutils = require('semver-utils');
-const Promise = require('bluebird');
 const ProgressBar = require('progress');
 const packageJson = require('package-json');
 const versionUtil = require('./version-util.js');
@@ -403,7 +402,7 @@ function queryVersions(packageMap, options = {}) {
         });
     }
 
-    return Promise.map(packageList, getPackageVersionProtected)
+    return Promise.all(packageList.map(getPackageVersionProtected))
         .then(zipVersions)
         .then(_.partialRight(_.pickBy, _.identity));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -156,9 +156,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
+      "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -184,9 +184,9 @@
       }
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
+      "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -2717,9 +2717,9 @@
       "dev": true
     },
     "import-fresh": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
-      "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.1.0.tgz",
+      "integrity": "sha512-PpuksHKGt8rXfWEr9m9EHIpgyyaltBy8+eF6GJM0QCAxMgxCfucMF3mjecK2QsJr0amJW7gTqh5/wht0z2UhEQ==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   },
   "homepage": "https://github.com/tjunnone/npm-check-updates",
   "dependencies": {
-    "bluebird": "^3.5.5",
     "chalk": "^2.4.2",
     "cint": "^8.2.1",
     "cli-table": "^0.3.1",

--- a/test/test-ncu.js
+++ b/test/test-ncu.js
@@ -12,6 +12,11 @@ describe('npm-check-updates', function () {
 
     this.timeout(30000);
 
+    let last = 0;
+    function getTempFile() {
+        return `test/temp_package${++last}.json`;
+    }
+
     describe('run', () => {
         it('should return promised jsonUpgraded', () => {
             return ncu.run({
@@ -107,7 +112,7 @@ describe('npm-check-updates', function () {
 
         it('should write to --packageFile and output jsonUpgraded', async () => {
 
-            const tempFile = 'test/temp_package.json';
+            const tempFile = getTempFile();
             fs.writeFileSync(tempFile, '{ "dependencies": { "express": "1" } }', 'utf-8');
 
             try {
@@ -268,7 +273,7 @@ describe('npm-check-updates', function () {
         });
 
         it('should read --packageFile', async () => {
-            const tempFile = 'test/temp_package.json';
+            const tempFile = getTempFile();
             fs.writeFileSync(tempFile, '{ "dependencies": { "express": "1" } }', 'utf-8');
             try {
                 const text = await spawn('node', ['bin/ncu', '--jsonUpgraded', '--packageFile', tempFile]);
@@ -280,7 +285,7 @@ describe('npm-check-updates', function () {
         });
 
         it('should write to --packageFile', async () => {
-            const tempFile = 'test/temp_package.json';
+            const tempFile = getTempFile();
             fs.writeFileSync(tempFile, '{ "dependencies": { "express": "1" } }', 'utf-8');
             try {
                 await spawn('node', ['bin/npm-check-updates', '-u', '--packageFile', tempFile]);
@@ -294,7 +299,7 @@ describe('npm-check-updates', function () {
         });
 
         it('should not write to --packageFile if error-level=2 and upgrades', () => {
-            const tempFile = 'test/temp_package.json';
+            const tempFile = getTempFile();
             fs.writeFileSync(tempFile, '{ "dependencies": { "express": "1" } }', 'utf-8');
 
             (async () => {
@@ -311,7 +316,7 @@ describe('npm-check-updates', function () {
         });
 
         it('should write to --packageFile with jsonUpgraded flag', async () => {
-            const tempFile = 'test/temp_package.json';
+            const tempFile = getTempFile();
             fs.writeFileSync(tempFile, '{ "dependencies": { "express": "1" } }', 'utf-8');
             try {
                 await spawn('node', ['bin/npm-check-updates', '-u', '--jsonUpgraded', '--packageFile', tempFile]);
@@ -319,13 +324,13 @@ describe('npm-check-updates', function () {
                 ugradedPkg.should.have.property('dependencies');
                 ugradedPkg.dependencies.should.have.property('express');
                 ugradedPkg.dependencies.express.should.not.equal('1');
-            } finally  {
+            } finally {
                 fs.unlinkSync(tempFile);
             }
         });
 
         it('should ignore stdin if --packageFile is specified', async () => {
-            const tempFile = 'test/temp_package.json';
+            const tempFile = getTempFile();
             fs.writeFileSync(tempFile, '{ "dependencies": { "express": "1" } }', 'utf-8');
             try {
                 await spawn('node', ['bin/npm-check-updates', '-u', '--packageFile', tempFile], '{ "dependencies": {}}');

--- a/test/test-ncu.js
+++ b/test/test-ncu.js
@@ -267,77 +267,75 @@ describe('npm-check-updates', function () {
                 });
         });
 
-        it('should read --packageFile', () => {
+        it('should read --packageFile', async () => {
             const tempFile = 'test/temp_package.json';
             fs.writeFileSync(tempFile, '{ "dependencies": { "express": "1" } }', 'utf-8');
-            return spawn('node', ['bin/ncu', '--jsonUpgraded', '--packageFile', tempFile])
-                .then(JSON.parse)
-                .then(pkgData => {
-                    pkgData.should.have.property('express');
-                })
-                .finally(() => {
-                    fs.unlinkSync(tempFile);
-                });
+            try {
+                const text = await spawn('node', ['bin/ncu', '--jsonUpgraded', '--packageFile', tempFile]);
+                const pkgData = JSON.parse(text);
+                pkgData.should.have.property('express');
+            } finally {
+                fs.unlinkSync(tempFile);
+            }
         });
 
-        it('should write to --packageFile', () => {
+        it('should write to --packageFile', async () => {
             const tempFile = 'test/temp_package.json';
             fs.writeFileSync(tempFile, '{ "dependencies": { "express": "1" } }', 'utf-8');
-            return spawn('node', ['bin/npm-check-updates', '-u', '--packageFile', tempFile])
-                .then(() => {
-                    const upgradedPkg = JSON.parse(fs.readFileSync(tempFile, 'utf-8'));
-                    upgradedPkg.should.have.property('dependencies');
-                    upgradedPkg.dependencies.should.have.property('express');
-                    upgradedPkg.dependencies.express.should.not.equal('1');
-                })
-                .finally(() => {
-                    fs.unlinkSync(tempFile);
-                });
+            try {
+                await spawn('node', ['bin/npm-check-updates', '-u', '--packageFile', tempFile]);
+                const upgradedPkg = JSON.parse(fs.readFileSync(tempFile, 'utf-8'));
+                upgradedPkg.should.have.property('dependencies');
+                upgradedPkg.dependencies.should.have.property('express');
+                upgradedPkg.dependencies.express.should.not.equal('1');
+            } finally {
+                fs.unlinkSync(tempFile);
+            }
         });
 
         it('should not write to --packageFile if error-level=2 and upgrades', () => {
             const tempFile = 'test/temp_package.json';
             fs.writeFileSync(tempFile, '{ "dependencies": { "express": "1" } }', 'utf-8');
 
-            return spawn('node', ['bin/ncu', '-u', '--error-level', '2', '--packageFile', tempFile])
-                .finally(() => {
+            (async () => {
+                try {
+                    await spawn('node', ['bin/ncu', '-u', '--error-level', '2', '--packageFile', tempFile]);
+                } finally {
                     const upgradedPkg = JSON.parse(fs.readFileSync(tempFile, 'utf-8'));
                     fs.unlinkSync(tempFile);
                     upgradedPkg.should.have.property('dependencies');
                     upgradedPkg.dependencies.should.have.property('express');
                     upgradedPkg.dependencies.express.should.equal('1');
-                })
-                .should.eventually.be.rejectedWith('Dependencies not up-to-date');
+                }
+            })().should.eventually.be.rejectedWith('Dependencies not up-to-date');
         });
 
-        it('should write to --packageFile with jsonUpgraded flag', () => {
+        it('should write to --packageFile with jsonUpgraded flag', async () => {
             const tempFile = 'test/temp_package.json';
             fs.writeFileSync(tempFile, '{ "dependencies": { "express": "1" } }', 'utf-8');
-            return spawn('node', ['bin/npm-check-updates', '-u', '--jsonUpgraded', '--packageFile', tempFile])
-                .then(() => {
-                    const ugradedPkg = JSON.parse(fs.readFileSync(tempFile, 'utf-8'));
-                    ugradedPkg.should.have.property('dependencies');
-                    ugradedPkg.dependencies.should.have.property('express');
-                    ugradedPkg.dependencies.express.should.not.equal('1');
-                })
-                .finally(() => {
-                    fs.unlinkSync(tempFile);
-                });
+            try {
+                await spawn('node', ['bin/npm-check-updates', '-u', '--jsonUpgraded', '--packageFile', tempFile]);
+                const ugradedPkg = JSON.parse(fs.readFileSync(tempFile, 'utf-8'));
+                ugradedPkg.should.have.property('dependencies');
+                ugradedPkg.dependencies.should.have.property('express');
+                ugradedPkg.dependencies.express.should.not.equal('1');
+            } finally  {
+                fs.unlinkSync(tempFile);
+            }
         });
 
-        it('should ignore stdin if --packageFile is specified', () => {
+        it('should ignore stdin if --packageFile is specified', async () => {
             const tempFile = 'test/temp_package.json';
             fs.writeFileSync(tempFile, '{ "dependencies": { "express": "1" } }', 'utf-8');
-            return spawn('node', ['bin/npm-check-updates', '-u', '--packageFile', tempFile], '{ "dependencies": {}}')
-                .then(() => {
-                    const upgradedPkg = JSON.parse(fs.readFileSync(tempFile, 'utf-8'));
-                    upgradedPkg.should.have.property('dependencies');
-                    upgradedPkg.dependencies.should.have.property('express');
-                    upgradedPkg.dependencies.express.should.not.equal('1');
-                })
-                .finally(() => {
-                    fs.unlinkSync(tempFile);
-                });
+            try {
+                await spawn('node', ['bin/npm-check-updates', '-u', '--packageFile', tempFile], '{ "dependencies": {}}');
+                const upgradedPkg = JSON.parse(fs.readFileSync(tempFile, 'utf-8'));
+                upgradedPkg.should.have.property('dependencies');
+                upgradedPkg.dependencies.should.have.property('express');
+                upgradedPkg.dependencies.express.should.not.equal('1');
+            } finally {
+                fs.unlinkSync(tempFile);
+            }
         });
 
         it('should filter by package name with --filter', () => {
@@ -401,49 +399,46 @@ describe('npm-check-updates', function () {
                 });
         });
 
-        it('should read --configFilePath', () => {
+        it('should read --configFilePath', async () => {
             const tempFilePath = './test/';
             const tempFileName = '.ncurc.json';
             fs.writeFileSync(tempFilePath + tempFileName, '{"jsonUpgraded": true, "filter": "express"}', 'utf-8');
-            return spawn('node', ['bin/ncu', '--configFilePath', tempFilePath], '{ "dependencies": { "express": "1", "chalk": "0.1.0" } }')
-                .then(JSON.parse)
-                .then(pkgData => {
-                    pkgData.should.have.property('express');
-                    pkgData.should.not.have.property('chalk');
-                })
-                .finally(() => {
-                    fs.unlinkSync(tempFilePath + tempFileName);
-                });
+            try {
+                const text = await spawn('node', ['bin/ncu', '--configFilePath', tempFilePath], '{ "dependencies": { "express": "1", "chalk": "0.1.0" } }');
+                const pkgData = JSON.parse(text);
+                pkgData.should.have.property('express');
+                pkgData.should.not.have.property('chalk');
+            } finally {
+                fs.unlinkSync(tempFilePath + tempFileName);
+            }
         });
 
-        it('should read --configFileName', () => {
+        it('should read --configFileName', async () => {
             const tempFilePath = './test/';
             const tempFileName = '.rctemp.json';
             fs.writeFileSync(tempFilePath + tempFileName, '{"jsonUpgraded": true, "filter": "express"}', 'utf-8');
-            return spawn('node', ['bin/ncu', '--configFilePath', tempFilePath, '--configFileName', tempFileName], '{ "dependencies": { "express": "1", "chalk": "0.1.0" } }')
-                .then(JSON.parse)
-                .then(pkgData => {
-                    pkgData.should.have.property('express');
-                    pkgData.should.not.have.property('chalk');
-                })
-                .finally(() => {
-                    fs.unlinkSync(tempFilePath + tempFileName);
-                });
+            try {
+                const text = await spawn('node', ['bin/ncu', '--configFilePath', tempFilePath, '--configFileName', tempFileName], '{ "dependencies": { "express": "1", "chalk": "0.1.0" } }');
+                const pkgData = JSON.parse(text);
+                pkgData.should.have.property('express');
+                pkgData.should.not.have.property('chalk');
+            } finally {
+                fs.unlinkSync(tempFilePath + tempFileName);
+            }
         });
 
-        it('should override config with arguments', () => {
+        it('should override config with arguments', async () => {
             const tempFilePath = './test/';
             const tempFileName = '.ncurc.json';
             fs.writeFileSync(tempFilePath + tempFileName, '{"jsonUpgraded": true, "filter": "express"}', 'utf-8');
-            return spawn('node', ['bin/ncu', '--configFilePath', tempFilePath, '--filter', 'chalk'], '{ "dependencies": { "express": "1", "chalk": "0.1.0" } }')
-                .then(JSON.parse)
-                .then(pkgData => {
-                    pkgData.should.have.property('chalk');
-                    pkgData.should.not.have.property('express');
-                })
-                .finally(() => {
-                    fs.unlinkSync(tempFilePath + tempFileName);
-                });
+            try {
+                const text = await spawn('node', ['bin/ncu', '--configFilePath', tempFilePath, '--filter', 'chalk'], '{ "dependencies": { "express": "1", "chalk": "0.1.0" } }');
+                const pkgData = JSON.parse(text);
+                pkgData.should.have.property('chalk');
+                pkgData.should.not.have.property('express');
+            } finally {
+                fs.unlinkSync(tempFilePath + tempFileName);
+            }
         });
 
         describe('with timeout option', () => {


### PR DESCRIPTION
Node.js has great support for Promise for all versions supported by `npm-check-udpates`. This pull request removes the dependency for `bluebird`.