### PR TITLE
Clarify filter argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Check global packages:
 $ ncu -g           # add -u to get a one-line command for upgrading
 ```
 
-You can include or exclude specific packages using the `--filter` and `--reject` options. They accept strings, comma-delimited lists, or regular expressions:
+You can include or exclude specific packages using the `--filter` and `--reject` options. They accept strings, comma-or-space-delimited lists, or regular expressions:
 
 ```sh
 # match mocha and should packages exactly
@@ -94,7 +94,7 @@ Options
                              packages need updating (useful for continuous
                              integration)
     -f, --filter             include only package names matching the given string,
-                             comma-delimited list, or regex
+                             comma-or-space-delimited list, or /regex/
     -g, --global             check global packages instead of in the current project
     -i, --interactive        Enable interactive prompts for each dependency
     -j, --jsonAll            output new package file instead of human-readable

--- a/bin/ncu
+++ b/bin/ncu
@@ -21,7 +21,7 @@ program
     .usage('[options] [filter]')
     .option('--dep <dep>', 'check only a specific section(s) of dependencies: prod|dev|peer|optional|bundle (comma-delimited)')
     .option('-e, --error-level <n>', 'set the error-level. 1: exits with error code 0 if no errors occur. 2: exits with error code 0 if no packages need updating (useful for continuous integration). Default is 1.', cint.partialAt(parseInt, 1, 10), 1)
-    .option('-f, --filter <matches>', 'include only package names matching the given string, comma-delimited list, or regex')
+    .option('-f, --filter <matches>', 'include only package names matching the given string, comma-or-space-delimited list, or /regex/')
     .option('-g, --global', 'check global packages instead of in the current project')
     // program.json is set to true in programInit if any options that begin with 'json' are true
     .option('-i, --interactive', 'Enable interactive prompts for each dependency')
@@ -42,7 +42,7 @@ program
     .option('-t, --greatest', 'find the highest versions available instead of the latest stable versions')
     .option('--timeout <ms>', 'a global timeout in ms')
     .option('-u, --upgrade', 'overwrite package file')
-    .option('-x, --reject <matches>', 'exclude packages matching the given string, comma-delimited list, or regex')
+    .option('-x, --reject <matches>', 'exclude packages matching the given string, comma-or-space-delimited list, or /regex/')
     .option('--semverLevel <level>', 'find the highest version within "major" or "minor"')
     .option('--removeRange', 'remove version ranges from the final package version')
     .option('-v, --version', pkg.version, () => {


### PR DESCRIPTION
Make it clearer that the filter and exclude arguments can take space-delimited lists and that regexes must be enclosed by `/`.