### PR TITLE
Disable pacote cacache

### DIFF
--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -17,6 +17,7 @@ require('libnpmconfig').read().forEach((value, key) => {
             process.env[envVar]
         );
 });
+npmConfig.cache = false;
 
 /** Parse JSON and throw an informative error on failure.
  * @param result Data to be parsed


### PR DESCRIPTION
[pacote caches stuff](https://github.com/npm/pacote#features) using [cacache](https://www.npmjs.com/package/cacache), which sometimes returns outdated or incomplete (that might be a pacote bug) results. Since ncu should imho always return the up-to-date result, I'd suggest disabling the cache altogether for now.

Fixes #576 