### PR TITLE
Fix global dependencies message

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -142,16 +142,19 @@ function analyzeGlobalPackages(options) {
                 .then(([upgraded, latest]) => {
                     print(options, latest, 'silly');
 
+                    const upgradedPackageNames = Object.keys(upgraded);
                     const upgradePromise = printUpgrades(options, {
                         current: globalPackages,
                         upgraded,
                         latest,
-                        total: Object.keys(upgraded).length
+                        // since an interactive upgrade of globals is not available, the numUpgraded is always all
+                        numUpgraded: upgradedPackageNames.length,
+                        total: upgradedPackageNames.length
                     });
 
                     let instruction = '[package]';
                     if (upgraded) {
-                        instruction = Object.keys(upgraded).map(pkg => pkg + '@' + upgraded[pkg]).join(' ');
+                        instruction = upgradedPackageNames.map(pkg => pkg + '@' + upgraded[pkg]).join(' ');
                     }
 
                     if (options.json) {
@@ -249,8 +252,8 @@ function analyzeProjectDependencies(options, pkgData, pkgFile) {
  * @param {Object} args - The arguments passed to the function.
  * @param {Object} args.current - The current packages.
  * @param {Object} args.upgraded - The packages that should be upgraded.
- * @param {number} [args.numUpgraded] - The number of upgraded packages (optional)
- * @param {number} [args.total] - The total number of all possible upgrades (optional)
+ * @param {number} args.numUpgraded - The number of upgraded packages
+ * @param {number} args.total - The total number of all possible upgrades
  */
 function printUpgrades(options, {current, upgraded, numUpgraded, total}) {
     print(options, '');


### PR DESCRIPTION
Fixes regression introduced in #577 

Please test thoroughly 😉 

global ncu vs. local (this PR):
<img width="389" alt="Bildschirmfoto 2019-09-10 um 20 05 24" src="https://user-images.githubusercontent.com/1742115/64638858-ed70dd80-d406-11e9-8cc5-398a37c0c1b8.png">
