### PR TITLE
- npm: Add recommended `bugs` field (used on npmjs.com)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "url": "https://github.com/tjunnone/npm-check-updates.git"
   },
   "homepage": "https://github.com/tjunnone/npm-check-updates",
+  "bugs": "https://github.com/tjunnone/npm-check-updates/issues",
   "dependencies": {
     "chalk": "^2.4.2",
     "cint": "^8.2.1",


### PR DESCRIPTION
Btw, re: `package.json`, I don't know your frequency of updating your own deps, so I didn't update those.

This field is useful on npmjs.com for pointing directly to the issues page. (and it quiets my `package.json` linter!)

Also, the snyk tests failed (and were failing before my changes) due to the need for one patch; not sure how you wanted to resolve.