### PR TITLE
Expose ncurc retrieval to programmatic API

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ $ ncu '/^(?!gulp-).*$/'
 Options
 --------------
 
-    --configFilePath         rc config file path (default: ./)
+    --configFilePath         rc config file path (default: directory of `packageFile` or ./ otherwise)
     --configFileName         rc config file name (default: .ncurc.{json,yml,js})                             
     --dep                    check only a specific section(s) of dependencies:
                              prod|dev|peer|optional|bundle (comma-delimited)
@@ -109,7 +109,7 @@ Options
     -p, --packageManager     npm or bower (default: npm)
     --packageData            include stringified package file (use stdin instead)
     --packageFile            package file location (default: ./package.json)
-    --pre                    include -alpha, -beta, -rc. Default: 0. Default 
+    --pre                    include -alpha, -beta, -rc. Default: 0. Default
                              with --newest and --greatest: 1.
     -r, --registry           specify third-party NPM registry
     --removeRange            remove version ranges from the final package version

--- a/bin/ncu
+++ b/bin/ncu
@@ -54,11 +54,12 @@ program
 
 program.parse(process.argv);
 
-const {configFileName, configFilePath} = program;
+const {configFileName, configFilePath, packageFile} = program;
 
 const rcConfig = ncu.getNcurc({
     configFileName,
-    configFilePath
+    configFilePath,
+    packageFile
 });
 
 const rcArguments = rcConfig ?

--- a/bin/ncu
+++ b/bin/ncu
@@ -18,7 +18,7 @@ if (notifier.update && notifier.update.latest !== pkg.version) {
 program
     .description('[filter] is a list or regex of package names to check (all others will be ignored).')
     .usage('[options] [filter]')
-    .option('--configFilePath <path>', 'rc config file path (default: ./)')
+    .option('--configFilePath <path>', 'rc config file path (default: directory of `packageFile` or ./ otherwise)')
     .option('--configFileName <path>', 'rc config file name (default: .ncurc.{json,yml,js})')
     .option('--dep <dep>', 'check only a specific section(s) of dependencies: prod|dev|peer|optional|bundle (comma-delimited)')
     .option('-e, --error-level <n>', 'set the error-level. 1: exits with error code 0 if no errors occur. 2: exits with error code 0 if no packages need updating (useful for continuous integration). Default is 1.', cint.partialAt(parseInt, 1, 10), 1)

--- a/bin/ncu
+++ b/bin/ncu
@@ -6,7 +6,6 @@ const program = require('commander');
 const updateNotifier = require('update-notifier');
 const cint = require('cint');
 const _ = require('lodash');
-const rcLoader = require('rc-config-loader');
 const ncu = require('../lib/npm-check-updates');
 const pkg = require('../package.json');
 
@@ -55,14 +54,15 @@ program
 
 program.parse(process.argv);
 
-const rcFile = rcLoader('ncurc', {
-    configFileName: program.configFileName || '.ncurc',
-    defaultExtension: ['.json', '.yml', '.js'],
-    cwd: program.configFilePath || undefined
+const {configFileName, configFilePath} = program;
+
+const rcConfig = ncu.getNcurc({
+    configFileName,
+    configFilePath
 });
 
-const rcArguments = rcFile && rcFile.config ?
-    _.flatten(_.map(rcFile.config, (value, name) =>
+const rcArguments = rcConfig ?
+    _.flatten(_.map(rcConfig, (value, name) =>
         value === true ? [`--${name}`] : [`--${name}`, value]
     )) : [];
 

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -445,9 +445,8 @@ function getNcurc({configFileName, configFilePath, packageFile} = {}) {
     const rcFile = rcLoader('ncurc', {
         configFileName: configFileName || '.ncurc',
         defaultExtension: ['.json', '.yml', '.js'],
-        cwd: packageFile ?
-            path.dirname(packageFile) :
-            configFilePath || undefined
+        cwd: configFilePath ||
+            (packageFile ? path.dirname(packageFile) : undefined)
     });
     return rcFile && rcFile.config;
 }

--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -13,6 +13,7 @@ const Table = require('cli-table');
 const chalk = require('chalk');
 const {promisify} = require('util');
 const fs = require('fs');
+const rcLoader = require('rc-config-loader');
 const vm = require('./versionmanager');
 const packageManagers = require('./package-managers');
 const versionUtil = require('./version-util');
@@ -433,6 +434,25 @@ async function run(options={}) {
     return await Promise.race([timeoutPromise, getAnalysis()]);
 }
 
+/**
+ * @param {PlainObject} [cfg]
+ * @param {string} [cfg.configFileName=".ncurc"]
+ * @param {string} [cfg.configFilePath]
+ * @param {string} [cfg.packageFile]
+ * @returns {PlainObject|undefined}
+ */
+function getNcurc({configFileName, configFilePath, packageFile} = {}) {
+    const rcFile = rcLoader('ncurc', {
+        configFileName: configFileName || '.ncurc',
+        defaultExtension: ['.json', '.yml', '.js'],
+        cwd: packageFile ?
+            path.dirname(packageFile) :
+            configFilePath || undefined
+    });
+    return rcFile && rcFile.config;
+}
+
 module.exports = _.assign({
-    run
+    run,
+    getNcurc
 }, vm);


### PR DESCRIPTION
I needed this with some programmatic usage, and thought it best for your other consumers not to have to duplicate this or resort to the CLI to get ncurc retrieval logic.

One breaking change I did not make (though I made it easier to implement if you want to go that route), but which I think would be useful--allow the rcLoader current working directory to be based by default on the directory of `packageFile`, since they would presumably usually be in the same (project root) directory.