### PR TITLE
Jsdoc

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -304,8 +304,14 @@ function initOptions(options) {
     });
 }
 
+/**
+* @typedef {Array} PkgInfo
+* @property 0 pkgFile
+* @property 1 pkgData
+*/
+
 /** Finds the package file and data.
-    @returns Promise [pkgFile, pkgData]
+    @returns Promise<PkgInfo>
 
 Searches as follows:
  --packageData flag

--- a/lib/package-managers/bower.js
+++ b/lib/package-managers/bower.js
@@ -4,6 +4,7 @@ const chalk = require('chalk');
 const requireg = require('requireg');
 
 /**
+ * @param args
  * @param args.global
  * @param args.registry
  * @param args.loglevel
@@ -24,6 +25,12 @@ const bower = ({loglevel}) => {
 
 module.exports = {
 
+    /**
+     * @param {Object} [info]
+     * @param {string} info.prefix
+     * @param {string} info.loglevel
+     * @returns {Promise<Object>}
+     */
     list({prefix, loglevel} = {}) {
 
         return new Promise((resolve, reject) => {
@@ -37,6 +44,14 @@ module.exports = {
         });
     },
 
+    /**
+     * @param {string} packageName
+     * @param _
+     * @param {Object} [info]
+     * @param {string} info.prefix
+     * @param {string} info.loglevel
+     * @returns {Promise}
+     */
     latest(packageName, _, {prefix, loglevel} = {}) {
 
         return new Promise((resolve, reject) => {
@@ -51,6 +66,14 @@ module.exports = {
         });
     },
 
+    /**
+     * @param {string} packageName
+     * @param _
+     * @param {Object} [info]
+     * @param {string} info.prefix
+     * @param {string} info.loglevel
+     * @returns {Promise}
+     */
     greatest(packageName, _, {prefix, loglevel} = {}) {
 
         return new Promise((resolve, reject) => {

--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -19,9 +19,17 @@ require('libnpmconfig').read().forEach((value, key) => {
 });
 npmConfig.cache = false;
 
-/** Parse JSON and throw an informative error on failure.
+/**
+* @typedef {Object} CommandAndPackageName
+* @property {string} command
+* @property {string} packageName
+*/
+
+/**
+ * Parse JSON and throw an informative error on failure.
  * @param result Data to be parsed
- * @param data { command, packageName }
+ * @param {CommandAndPackageName} data
+ * @returns {Object}
 */
 function parseJson(result, data) {
     let json;
@@ -35,9 +43,10 @@ function parseJson(result, data) {
 }
 
 /**
- * @param packageName   Name of the package
- * @param field         Field such as "versions" or "dist-tags.latest" are parsed from the pacote result (https://www.npmjs.com/package/pacote#packument)
- * @returns             Promised result
+ * @param {string} packageName   Name of the package
+ * @param {string} field         Field such as "versions" or "dist-tags.latest" are parsed from the pacote result (https://www.npmjs.com/package/pacote#packument)
+ * @param {string} currentVersion
+ * @returns {Promise}             Promised result
  */
 function view(packageName, field, currentVersion) {
     if (currentVersion && (!semver.validRange(currentVersion) || versionUtil.isWildCard(currentVersion))) {
@@ -61,8 +70,8 @@ function view(packageName, field, currentVersion) {
 }
 
 /**
- * @param versions  Array of all available versions
- * @returns         An array of versions with the release versions filtered out
+ * @param {Array} versions  Array of all available versions
+ * @returns {Array}         An array of versions with the release versions filtered out
  */
 function filterOutPrereleaseVersions(versions) {
     return _.filter(versions, _.negate(isPre));
@@ -77,7 +86,13 @@ function isPre(version) {
 }
 
 
-/** Spawn npm requires a different command on Windows. */
+/**
+ * Spawn npm requires a different command on Windows.
+ * @param args
+ * @param {Object} [npmOptions={}]
+ * @param {Object} [spawnOptions={}]
+ * @returns {Promise<string>}
+ */
 function spawnNpm(args, npmOptions={}, spawnOptions={}) {
     const cmd = process.platform === 'win32'? 'npm.cmd' : 'npm';
 
@@ -92,8 +107,10 @@ function spawnNpm(args, npmOptions={}, spawnOptions={}) {
 }
 
 /** Get platform-specific default prefix to pass on to npm.
- * @param options.global
- * @param options.prefix
+ * @param {Object} options
+ * @param {boolean} [options.global]
+ * @param [options.prefix]
+ * @returns {Promise<string>}
 */
 function defaultPrefix(options) {
 
@@ -139,6 +156,12 @@ module.exports = {
             });
     },
 
+    /**
+     * @param {string} packageName
+     * @param {string} currentVersion
+     * @param {boolean} pre
+     * @returns {Promise}
+     */
     latest(packageName, currentVersion, pre) {
         return view(packageName, 'dist-tags.latest', currentVersion)
             .then(version => {
@@ -156,6 +179,12 @@ module.exports = {
             });
     },
 
+    /**
+     * @param {string} packageName
+     * @param {string} currentVersion
+     * @param {boolean} pre
+     * @returns {Promise}
+     */
     newest(packageName, currentVersion, pre) {
         return view(packageName, 'time', currentVersion)
             .then(_.keys)
@@ -165,6 +194,12 @@ module.exports = {
             });
     },
 
+    /**
+     * @param {string} packageName
+     * @param {string} currentVersion
+     * @param {boolean} pre
+     * @returns {Promise}
+     */
     greatest(packageName, currentVersion, pre) {
         return view(packageName, 'versions', currentVersion)
             .then(versions => {
@@ -172,6 +207,12 @@ module.exports = {
             });
     },
 
+    /**
+     * @param {string} packageName
+     * @param {string} currentVersion
+     * @param {boolean} pre
+     * @returns {Promise}
+     */
     greatestMajor(packageName, currentVersion, pre) {
         return view(packageName, 'versions', currentVersion).then(versions => {
             const resultVersions = pre ? versions : filterOutPrereleaseVersions(versions);
@@ -179,6 +220,12 @@ module.exports = {
         });
     },
 
+    /**
+     * @param {string} packageName
+     * @param {string} currentVersion
+     * @param {boolean} pre
+     * @returns {Promise}
+     */
     greatestMinor(packageName, currentVersion, pre) {
         return view(packageName, 'versions', currentVersion).then(versions => {
             const resultVersions = pre ? versions : filterOutPrereleaseVersions(versions);

--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -114,7 +114,7 @@ function spawnNpm(args, npmOptions={}, spawnOptions={}) {
 */
 function defaultPrefix(options) {
 
-    if (options && options.prefix) {
+    if (options.prefix) {
         return Promise.resolve(options.prefix);
     }
 

--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -37,7 +37,7 @@ function parseJson(result, data) {
 /**
  * @param packageName   Name of the package
  * @param field         Field such as "versions" or "dist-tags.latest" are parsed from the pacote result (https://www.npmjs.com/package/pacote#packument)
- * @Returns             Promised result
+ * @returns             Promised result
  */
 function view(packageName, field, currentVersion) {
     if (currentVersion && (!semver.validRange(currentVersion) || versionUtil.isWildCard(currentVersion))) {
@@ -62,7 +62,7 @@ function view(packageName, field, currentVersion) {
 
 /**
  * @param versions  Array of all available versions
- * @Returns         An array of versions with the release versions filtered out
+ * @returns         An array of versions with the release versions filtered out
  */
 function filterOutPrereleaseVersions(versions) {
     return _.filter(versions, _.negate(isPre));
@@ -70,7 +70,7 @@ function filterOutPrereleaseVersions(versions) {
 
 /**
  * @param            version
- * @Returns          True if the version is any kind of prerelease: alpha, beta, rc, pre
+ * @returns {boolean}          True if the version is any kind of prerelease: alpha, beta, rc, pre
  */
 function isPre(version) {
     return versionUtil.getPrecision(version) === 'release';
@@ -119,9 +119,11 @@ function defaultPrefix(options) {
 module.exports = {
 
     /**
-     * @options.cwd (optional)
-     * @options.global (optional)
-     * @options.prefix (optional)
+     * @param [options]
+     * @param [options.cwd]
+     * @param [options.global]
+     * @param [options.prefix]
+     * @returns {Promise<Object>}
     */
     list(options={}) {
 

--- a/lib/raw-promisify.js
+++ b/lib/raw-promisify.js
@@ -5,6 +5,8 @@ const _ = require('lodash');
  * For some reason, Promise.promisifyAll does not work on npm.commands :(
  *   Promise.promisifyAll(npm.commands);
  * So we have to do it manually.
+ * @param {Object} obj
+ * @returns {void}
  */
 function rawPromisify(obj) {
     _.each(obj, (method, name) => {

--- a/lib/version-util.js
+++ b/lib/version-util.js
@@ -22,7 +22,8 @@ const WILDCARD_PURE_REGEX = new RegExp(`^(${WILDCARDS_PURE.join('|')
 const SEMANTIC_DIRECT = new RegExp('^\\d+\\.\\d+\\.\\d+([-|+].*)*$');
 
 /**
- * Returns the number of parts in the version
+ * @param {string} version
+ * @returns {number} The number of parts in the version
  */
 function numParts(version) {
 
@@ -37,6 +38,9 @@ function numParts(version) {
 
 /**
  * Increases or decreases the given precision by the given amount, e.g. major+1 -> minor
+ * @param {string} precision
+ * @param {number} n
+ * @returns {string}
  */
 function precisionAdd(precision, n) {
 
@@ -58,8 +62,13 @@ function precisionAdd(precision, n) {
     return VERSION_PARTS[index];
 }
 
-/** Joins the major, minor, patch, release, and build parts (controlled by an optional precision arg) of a semver object
- * into a dot-delimited string. */
+/**
+ * Joins the major, minor, patch, release, and build parts (controlled by an
+ * optional precision arg) of a semver object into a dot-delimited string.
+ * @param semver
+ * @param {string} [precision]
+ * @returns {string}
+ */
 function stringify(semver, precision) {
 
     // get a list of the parts up until (and including) the given precision
@@ -79,6 +88,8 @@ function stringify(semver, precision) {
 
 /**
  * Gets how precise this version number is (major, minor, patch, release, or build)
+ * @param {string} version
+ * @returns {string}
  */
 function getPrecision(version) {
     const semver = semverutils.parseRange(version)[0];
@@ -88,32 +99,52 @@ function getPrecision(version) {
 
 /**
  * Sets the precision of a (loose) semver to the specified level: major, minor, etc.
+ * @param {string} version
+ * @param {string} [precision]
+ * @returns {string}
  */
 function setPrecision(version, precision) {
     const semver = semverutils.parseRange(version)[0];
     return stringify(semver, precision);
 }
 
-/** Adds a given wildcard (^,~,.*,.x) to a version number. Adds ^ and ~ to the beginning. Replaces everything after the
- * major version number with .* or .x */
+/**
+ * Adds a given wildcard (^,~,.*,.x) to a version number. Adds ^ and ~ to the
+ * beginning. Replaces everything after the major version number with .* or .x
+ * @param {string} version
+ * @param {string} wildcard
+ * @returns {string}
+ */
 function addWildCard(version, wildcard) {
     return wildcard === '^' || wildcard === '~' ?
         wildcard + version :
         setPrecision(version, 'major') + wildcard;
 }
 
-/** Returns true if the given string is one of the wild cards. */
+/**
+ * Returns true if the given string is one of the wild cards.
+ * @param {string} version
+ * @returns {boolean}
+ */
 function isWildCard(version) {
     return WILDCARD_PURE_REGEX.test(version);
 }
 
-/** Returns true if the given digit is a wildcard for a part of a version. */
+/**
+ * Returns true if the given digit is a wildcard for a part of a version.
+ * @param {"*"|"x"} versionPart
+ * @returns {boolean}
+ */
 function isWildPart(versionPart) {
     return versionPart === '*' || versionPart === 'x';
 }
 
 /**
- * Colorize the parts of a version string (to) that are different than another (from). Assumes that the two verson strings are in the same format.
+ * Colorize the parts of a version string (to) that are different than
+ * another (from). Assumes that the two verson strings are in the same format.
+ * @param from
+ * @param to
+ * @returns {string}
  */
 function colorizeDiff(from, to) {
     let leadingWildcard = '';

--- a/lib/version-util.js
+++ b/lib/version-util.js
@@ -55,7 +55,8 @@ function precisionAdd(precision, n) {
 
     if (index === null) {
         throw new Error(`Invalid precision: ${precision}`);
-    } else if (!VERSION_PARTS[index]) {
+    }
+    if (!VERSION_PARTS[index]) {
         throw new Error(`Invalid precision math${arguments}`);
     }
 

--- a/lib/version-util.js
+++ b/lib/version-util.js
@@ -152,7 +152,7 @@ function colorizeDiff(from, to) {
  * @param versions  Array of all available versions
  * @param current   Current version
  * @param level     major/minor
- * @Returns         String representation of the suggested version. If the current version
+ * @returns {string}         String representation of the suggested version. If the current version
  * is not direct then returns null
  */
 function findGreatestByLevel(versions, current, level) {

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -146,10 +146,21 @@ function upgradeDependencies(currentDependencies, latestVersions, options = {}) 
 
 // Determines if the given version (range) should be upgraded to the latest (i.e. it is valid, it does not currently
 
-// Return true if the version satisfies the range
+/**
+ * Return true if the version satisfies the range.
+ * @type {function}
+ * @param {string} version
+ * @param {string} range
+ * @returns {boolean}
+ */
 const isSatisfied = semver.satisfies;
 
-// satisfy the latest, and it is not beyond the latest)
+/**
+ * Satisfy the latest, and it is not beyond the latest).
+ * @param {string} current
+ * @param {string} latest
+ * @returns {boolean}
+ */
 function isUpgradeable(current, latest) {
 
     // do not upgrade non-npm version declarations (such as git tags)
@@ -228,7 +239,7 @@ function filterAndReject(filter, reject) {
 }
 
 /**
- * Returns an 2-tuple of upgradedDependencies and their latest versions
+ * Returns an 2-tuple of upgradedDependencies and their latest versions.
  * @param {Object} currentDependencies
  * @param {Object} options
  * @returns {Array}
@@ -258,7 +269,7 @@ function upgradePackageDefinitions(currentDependencies, options) {
 }
 
 /**
- * Upgrade the dependency declarations in the package data
+ * Upgrade the dependency declarations in the package data.
  * @param {string} pkgData The package.json data, as utf8 text
  * @param {Object} oldDependencies Old dependencies {package: range}
  * @param {Object} newDependencies New dependencies {package: range}
@@ -300,7 +311,7 @@ async function upgradePackageData(pkgData, oldDependencies, newDependencies, new
 }
 
 /**
- * Get the current dependencies from the package file
+ * Get the current dependencies from the package file.
  * @param {Object} [pkgData={}] Object with dependencies, devDependencies, peerDependencies, optionalDependencies, and/or bundleDependencies properties
  * @param {Object} [options={}]
  * @param {string} options.dep
@@ -356,10 +367,10 @@ function getInstalledPackages(options = {}) {
 }
 
 /**
- * Get the latest or greatest versions from the NPM repository based on the version target
- * @param {Object} packageMap   an object whose keys are package name and values are current versions
- * @param {Object} [options={}]       Options. Default: { versionTarget: 'latest' }. You may also specify { versionTarget: 'greatest' }
- * @returns {Promise<Object>}             Promised {packageName: version} collection
+ * Get the latest or greatest versions from the NPM repository based on the version target.
+ * @param {Object} packageMap   An object whose keys are package name and values are current versions
+ * @param {Object} [options={}] Options. Default: { versionTarget: 'latest' }. You may also specify { versionTarget: 'greatest' }
+ * @returns {Promise<Object>} Promised {packageName: version} collection
  */
 function queryVersions(packageMap, options = {}) {
     let getPackageVersion;
@@ -426,7 +437,7 @@ function queryVersions(packageMap, options = {}) {
     }
 
     /**
-     * Zip up the array of versions into to a nicer object keyed by package name
+     * Zip up the array of versions into to a nicer object keyed by package name.
      * @param {Array} versionList
      * @returns {Object}
      */
@@ -493,6 +504,7 @@ function getVersionTarget(options) {
  * @param {string|Object} packageManagerNameOrObject
  * @param packageManagerNameOrObject.global
  * @param packageManagerNameOrObject.packageManager
+ * @returns {Object}
  */
 function getPackageManager(packageManagerNameOrObject) {
 

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -11,12 +11,21 @@ const prompts = require('prompts');
 // keep order for setPrecision
 const DEFAULT_WILDCARD = '^';
 
-/** Returns 'v' if the string starts with a v, otherwise returns empty string. */
+/**
+ * Returns 'v' if the string starts with a v, otherwise returns empty string.
+ * @param {string} str
+ * @returns {"v"|""}
+ */
 function v(str) {
     return str && (str[0] === 'v' || str[1] === 'v') ? 'v' : '';
 }
 
-/** Returns a new function that AND's the two functions over the provided arguments. */
+/**
+ * Returns a new function that AND's the two functions over the provided arguments.
+ * @param {function} f
+ * @param {function} g
+ * @returns {function}
+ */
 function and(f, g) {
     return function () {
         return f.apply(this, arguments) && g.apply(this, arguments);
@@ -101,7 +110,7 @@ function upgradeDependencyDeclaration(declaration, latestVersion, options = {}) 
  * @param currentDependencies current dependencies collection object
  * @param latestVersions latest available versions collection object
  * @param {Object} [options={}]
- * @returns {{}} upgraded dependency collection object
+ * @returns {Object} upgraded dependency collection object
  */
 function upgradeDependencies(currentDependencies, latestVersions, options = {}) {
     // filter out dependencies with empty values
@@ -165,7 +174,14 @@ function isUpgradeable(current, latest) {
 }
 
 /**
- * Creates a filter function from a given filter string. Supports strings, comma-or-space-delimited lists, and regexes.
+* @typedef {string|string[]|RegExp} FilterObject
+*/
+
+/**
+ * Creates a filter function from a given filter string. Supports
+ *   strings, comma-or-space-delimited lists, and regexes.
+ * @param {FilterObject} [filter]
+ * @returns {function}
  */
 function packageNameFilter(filter) {
 
@@ -198,7 +214,12 @@ function packageNameFilter(filter) {
     return cint.aritize(filterPackages, 1);
 }
 
-/** Creates a single filter function from an optional filter and optional reject. */
+/**
+ * Creates a single filter function from an optional filter and optional reject.
+ * @param {FilterObject} [filter]
+ * @param {FilterObject} [reject]
+ * @returns {function}
+ */
 function filterAndReject(filter, reject) {
     return and(
         filter ? packageNameFilter(filter) : _.identity,
@@ -206,7 +227,12 @@ function filterAndReject(filter, reject) {
     );
 }
 
-/** Returns an 2-tuple of upgradedDependencies and their latest versions */
+/**
+ * Returns an 2-tuple of upgradedDependencies and their latest versions
+ * @param {Object} currentDependencies
+ * @param {Object} options
+ * @returns {Array}
+ */
 function upgradePackageDefinitions(currentDependencies, options) {
     const versionTarget = getVersionTarget(options);
 
@@ -233,10 +259,10 @@ function upgradePackageDefinitions(currentDependencies, options) {
 
 /**
  * Upgrade the dependency declarations in the package data
- * @param pkgData The package.json data, as utf8 text
- * @param oldDependencies Object of old dependencies {package: range}
- * @param newDependencies Object of new dependencies {package: range}
- * @param newVersions Object of new versions {package: version}
+ * @param {string} pkgData The package.json data, as utf8 text
+ * @param {Object} oldDependencies Old dependencies {package: range}
+ * @param {Object} newDependencies New dependencies {package: range}
+ * @param {Object} newVersions New versions {package: version}
  * @param {Object} [options={}]
  * @returns {string} The updated package data, as utf8 text
  * @sideeffect prompts
@@ -277,10 +303,10 @@ async function upgradePackageData(pkgData, oldDependencies, newDependencies, new
  * Get the current dependencies from the package file
  * @param {Object} [pkgData={}] Object with dependencies, devDependencies, peerDependencies, optionalDependencies, and/or bundleDependencies properties
  * @param {Object} [options={}]
- * @param options.dep
+ * @param {string} options.dep
  * @param options.filter
  * @param options.reject
- * @returns Promised {packageName: version} collection
+ * @returns {Promise<Object>} Promised {packageName: version} collection
  */
 function getCurrentDependencies(pkgData = {}, options = {}) {
 
@@ -331,9 +357,9 @@ function getInstalledPackages(options = {}) {
 
 /**
  * Get the latest or greatest versions from the NPM repository based on the version target
- * @param packageMap   an object whose keys are package name and values are current versions
+ * @param {Object} packageMap   an object whose keys are package name and values are current versions
  * @param {Object} [options={}]       Options. Default: { versionTarget: 'latest' }. You may also specify { versionTarget: 'greatest' }
- * @returns             Promised {packageName: version} collection
+ * @returns {Promise<Object>}             Promised {packageName: version} collection
  */
 function queryVersions(packageMap, options = {}) {
     let getPackageVersion;
@@ -378,7 +404,12 @@ function queryVersions(packageMap, options = {}) {
         }
     }
 
-    // ignore 404 errors from getPackageVersion by having them return null instead of rejecting
+    /**
+     * Ignore 404 errors from getPackageVersion by having them return `null`
+     * instead of rejecting.
+     * @param dep
+     * @returns {Promise}
+     */
     function getPackageVersionProtected(dep) {
         return getPackageVersion(dep, packageMap[dep], options.pre).catch(err => {
             if (err && (err.message || err).toString().match(/E404|ENOTFOUND|404 Not Found/i)) {
@@ -394,7 +425,11 @@ function queryVersions(packageMap, options = {}) {
         });
     }
 
-    // zip up the array of versions into to a nicer object keyed by package name
+    /**
+     * Zip up the array of versions into to a nicer object keyed by package name
+     * @param {Array} versionList
+     * @returns {Object}
+     */
     function zipVersions(versionList) {
         return cint.toObject(versionList, (version, i) => {
             return cint.keyValue(packageList[i], version);
@@ -407,8 +442,11 @@ function queryVersions(packageMap, options = {}) {
 }
 
 /**
- * Given a dependencies collection, returns whether the user prefers ^, ~, .*, or .x (simply counts the greatest number
- * of occurrences). Returns null if given no dependencies.
+ *
+ * @param {Object} dependencies A dependencies collection
+ * @returns {string|null} Returns whether the user prefers ^, ~, .*, or .x
+ *   (simply counts the greatest number of occurrences) or `null` if
+ *   given no dependencies.
  */
 function getPreferredWildcard(dependencies) {
 
@@ -438,6 +476,11 @@ function getPreferredWildcard(dependencies) {
     return sorted.length > 0 ? sorted[0].wildcard : null;
 }
 
+/**
+ *
+ * @param {Object} options
+ * @returns {string}
+ */
 function getVersionTarget(options) {
     return options.semverLevel ? options.semverLevel :
         options.newest ? 'newest' :
@@ -447,8 +490,9 @@ function getVersionTarget(options) {
 
 /**
  * Initialize the version manager with the given package manager.
- * @param args.global
- * @param args.packageManager
+ * @param {string|Object} packageManagerNameOrObject
+ * @param packageManagerNameOrObject.global
+ * @param packageManagerNameOrObject.packageManager
  */
 function getPackageManager(packageManagerNameOrObject) {
 
@@ -471,6 +515,10 @@ function getPackageManager(packageManagerNameOrObject) {
 // Helper functions
 //
 
+/**
+ * @param {string} s
+ * @returns {string} String safe for use in `new RegExp()`
+ */
 function escapeRegexp(s) {
     return s.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&'); // Thanks Stack Overflow!
 }

--- a/lib/versionmanager.js
+++ b/lib/versionmanager.js
@@ -307,12 +307,13 @@ function getCurrentDependencies(pkgData = {}, options = {}) {
 }
 
 /**
- * @options.cwd
- * @options.filter
- * @options.global
- * @options.packageManager
- * @options.prefix
- * @options.reject
+ * @param [options]
+ * @param options.cwd
+ * @param options.filter
+ * @param options.global
+ * @param options.packageManager
+ * @param options.prefix
+ * @param options.reject
  */
 function getInstalledPackages(options = {}) {
     return getPackageManager(options.packageManager).list({cwd: options.cwd, prefix: options.prefix, global: options.global}).then(pkgInfoObj => {


### PR DESCRIPTION
- Use standard `jsdoc` tags and casing, denoting optional items (and add some types/return values)
- Minor refactoring: Remove `options` check in `npm.js`' `defaultPrefix` function as function does not later allow a non-object anyways
- Minor refactoring: Avoid else after throw

There is still one non-standard jsdoc-style tag you have in place (`@sideeffects`), but I didn't change that as there is no standard equivalent (there is a `@modifies` tag, but that is for side effects on objects) and JSDoc does allow custom tags.