### PR TITLE
Suggest to use npx as an alternative to install the package globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Installation
 npm install -g npm-check-updates
 ```
 
+Alternatively, you can use this package without installing it globally:
+
+```sh
+npx npm-check-updates
+```
+
+Note: `npx` comes with npm 5+.
+
 Usage
 --------------
 Show any new dependencies for the project in the current directory:


### PR DESCRIPTION
This PR documents an alternative way of using `npm-check-updates` without having to install it globally. It relies on npm's npx tool.