### PR TITLE
Added tests for invalid and wildCard ranges with --newest option

### DIFF
--- a/test/test-ncu.js
+++ b/test/test-ncu.js
@@ -226,6 +226,47 @@ describe('npm-check-updates', function () {
             });
         });
 
+        it('should work with --newest option with any invalid or wildcard range', () => {
+            return Promise.all([
+                ncu.run({
+                    jsonAll: true,
+                    newest: true,
+                    packageData: JSON.stringify({
+                        dependencies: {
+                            'del': ''
+                        }
+                    })
+                }),
+                ncu.run({
+                    jsonAll: true,
+                    newest: true,
+                    packageData: JSON.stringify({
+                        dependencies: {
+                            'del': 'invalid range'
+                        }
+                    })
+                }),
+                ncu.run({
+                    jsonAll: true,
+                    newest: true,
+                    packageData: JSON.stringify({
+                        dependencies: {
+                            'del': '*'
+                        }
+                    })
+                }),
+                ncu.run({
+                    jsonAll: true,
+                    newest: true,
+                    packageData: JSON.stringify({
+                        dependencies: {
+                            'del': '~'
+                        }
+                    })
+                })
+            ]);
+        });
+
         it('should enable --engines-node matching ', () => {
             return ncu.run({
                 jsonAll: true,


### PR DESCRIPTION
Fixed successful work in case of incorrect ranges.
For omitting errors like #608