### PR TITLE
Fix the good displayed log in interactive mode

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -235,7 +235,7 @@ function analyzeProjectDependencies(options, pkgData, pkgFile) {
             // if there is a package file, write the new package data
             // otherwise, suggest ncu -u
             if (pkgFile) {
-                if (options.upgrade) {
+                if (options.upgrade || options.interactive) {
                     // short-circuit return in order to wait for write operation, but still return the same output
                     return writePackageFile(pkgFile, newPkgData)
                         .then(() => {


### PR DESCRIPTION
Hello,

When using `ncu` in interactive mode i noticed it did not display the tip to launch `npm install` at the end like it does with `ncu -u`. I suggest this PR to allow to display this tip when the interactive mode installs at least one package.

Classic behaviour (for example)
```bash
あ→ ncu -u        
Upgrading /home/user/Documents/xxx/yyy/package.json
[====================] 36/36 100%

 cookie-universal-nuxt  ^2.0.18  →  ^2.0.19 
 eslint-plugin-nuxt       0.4.3  →    0.5.0

Run npm install to install new versions.
```

**Actual** interactive bahviour
```bash
あ→ ncu -i
Checking /home/user/Documents/xxx/yyy/package.json
[====================] 36/36 100%
✔ Do you want to upgrade: cookie-universal-nuxt ^2.0.18 → ^2.0.19? … yes
✔ Do you want to upgrade: eslint-plugin-nuxt 0.4.3 → 0.5.0? … no

 cookie-universal-nuxt  ^2.0.18  →  ^2.0.19 

Run ncu -u to upgrade package.json
```

**Expected** interactive bahviour (what the PR does)
```bash
あ→ ~/Downloads/npm-check-updates/bin/ncu -i
Checking /home/user/Documents/xxx/yyy/package.json
[====================] 36/36 100%
✔ Do you want to upgrade: cookie-universal-nuxt ^2.0.18 → ^2.0.19? … yes
✔ Do you want to upgrade: eslint-plugin-nuxt 0.4.3 → 0.5.0? … no

 cookie-universal-nuxt  ^2.0.18  →  ^2.0.19 

Run npm install to install new versions.  (<== this log looks better)
```

Be free to comment or to make another suggestion :)

Thank you for your work ;)