### PR TITLE
update "breaking changes" note in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![npm](https://badge.fury.io/js/npm-check-updates.svg)](http://badge.fury.io/js/npm-check-updates)
 [![Build Status](https://travis-ci.org/tjunnone/npm-check-updates.svg?branch=master)](https://travis-ci.org/tjunnone/npm-check-updates)
 
-> v3 released! See the [release notes](https://github.com/tjunnone/npm-check-updates/releases/tag/v3.0.0) for a description of breaking changes.
+> v4 released! See the [release notes](https://github.com/tjunnone/npm-check-updates/releases/tag/v4.0.0) for a description of breaking changes.
 
 **npm-check-updates upgrades your package.json dependencies to the *latest* versions, ignoring specified versions.**
 


### PR DESCRIPTION
Just a simple documentation fix according to latest release. 

Currently "breaking changes" note in `README.md` mention v3 instead of v4. This PR fixes that issue.