### PR TITLE
Apply lint to fix Travis build

### DIFF
--- a/lib/npm-check-updates.js
+++ b/lib/npm-check-updates.js
@@ -192,22 +192,22 @@ function analyzeProjectDependencies(options, pkgData, pkgFile) {
         options.enginesNode = _.get(pkg, 'engines.node');
     }
 
-    print(options, '\nOptions (partial):', 'verbose')
+    print(options, '\nOptions (partial):', 'verbose');
     print(options, {
         registry: options.registry ? options.registry : null,
         pre: options.pre,
         packageManager: options.packageManager,
         json: options.json,
         enginesNode: options.enginesNode
-    }, 'verbose')
+    }, 'verbose');
 
     return vm.upgradePackageDefinitions(current, options).then(async ([upgraded, latest]) => {
 
-        print(options, '\nFetched:', 'verbose')
-        print(options, latest, 'verbose')
+        print(options, '\nFetched:', 'verbose');
+        print(options, latest, 'verbose');
 
-        print(options, '\nUpgraded:', 'verbose')
-        print(options, upgraded, 'verbose')
+        print(options, '\nUpgraded:', 'verbose');
+        print(options, upgraded, 'verbose');
 
         const {newPkgData, selectedNewDependencies} = await vm.upgradePackageData(pkgData, current, upgraded, latest, options);
 


### PR DESCRIPTION
The travis build is failing due to missing semicolons at the `npm-check-updates.js` file.