### PR TITLE
Updating package manager npm for issue with ncu -g

### DIFF
--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -74,7 +74,7 @@ function viewMany(packageName, fields, currentVersion) {
         fields.reduce((accum, field) => Object.assign(
             accum,
             {
-                [field]: field.startsWith('dist-tags.') ?
+                [field]: field.startsWith('dist-tags.') && result.versions ?
                     result.versions[_.get(result, field)] :
                     result[field]
             }


### PR DESCRIPTION
The reduce() on line 77 assumes that all packages contain a versions field. Running against some global packages, this doesn't seem to be the case. In short you get the following error throw to the terminal: 

```
[=============-------] 55/84 65%/Users/cliveharber/.node/lib/node_modules/npm-check-updates/lib/npm-check-updates.js:412
    throw err;
    ^

TypeError: Cannot read property 'undefined' of undefined
    at /Users/cliveharber/.node/lib/node_modules/npm-check-updates/lib/package-managers/npm.js:78:36
    at Array.reduce (<anonymous>)
    at /Users/cliveharber/.node/lib/node_modules/npm-check-updates/lib/package-managers/npm.js:74:16
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async Promise.all (index 57)
    at async getAnalysis (/Users/cliveharber/.node/lib/node_modules/npm-check-updates/lib/npm-check-updates.js:453:30)
    at async Object.run (/Users/cliveharber/.node/lib/node_modules/npm-check-updates/lib/npm-check-updates.js:464:12)
```

This PR simply adds a check in to ensure that the versions field is present before trying to pick the associated value, other is falls back to the else part.

Fairly simple and easy to miss.