### PR TITLE
fix: declare namespace and remove async keyword

### DIFF
--- a/lib/npm-check-updates.d.ts
+++ b/lib/npm-check-updates.d.ts
@@ -1,4 +1,4 @@
-namespace ncu {
+declare namespace ncu {
   interface RunOptions {
     /**
      * rc config file path (default: directory of `packageFile` or ./ otherwise)
@@ -153,7 +153,7 @@ namespace ncu {
 
   type RunResults = Record<string, string>;
 
-  async function run(options?: RunOptions): Promise<RunResults>;
+  function run(options?: RunOptions): Promise<RunResults>;
 }
 
 export = ncu;


### PR DESCRIPTION
Building my project is failing because of issues in d.ts file. See the print screen. This PR should fix it.

Remove async - The fact that it returns a Promise is what makes it of async type.
Add declare keyword - Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier. Export can't be used because the ncu is exported.

![Screenshot 2020-03-25 at 09 21 19](https://user-images.githubusercontent.com/53510747/77518030-5852a500-6e7d-11ea-9225-86586479d786.png)

npm-check-updates: 4.0.5
Node: 12.13.0
YARN: 1.21.1
NPM: 6.12.0
TypeScript: 3.8.3