### PR TITLE
Fixes an issue which occurs if prefix is different than the npm default one

### DIFF
--- a/lib/package-managers/npm.js
+++ b/lib/package-managers/npm.js
@@ -152,7 +152,7 @@ function defaultPrefix(options) {
             // Workaround: get prefix on windows for global packages
             // Only needed when using npm api directly
             process.platform === 'win32' && options.global && !process.env.prefix ?
-                `${process.env.AppData}\\npm` :
+                prefix ? prefix.trim() : `${process.env.AppData}\\npm` :
                 null;
     });
 }


### PR DESCRIPTION
Trims since `npm config set prefix` appends a new line at the end of .npmrc This should probably be done for homebrew, as well, but I'm using it with Windows and am unaware of how it behaves under macOS, therefore, I don't know if the issue even occurs there. It most probably does, but if anybody can confirm it before I submit the second pull request, that be great.

To reproduce set npm prefix to a different folder and install a global package. After that run `ncu -g` and if you get `No dependencies.` then it does.